### PR TITLE
Install ImageIO headers in Opal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,25 @@
+2017-08-04  Daniel Ferreira <dtf@stanford.edu>
+
+	* Headers/ImageIO/ImageIO.h
+	* Headers/ImageIO/ImageIOBase.h
+	* Source/OpalGraphics/GNUmakefile.postamble:	
+	CGImageSource and CGImageDestination are not actually CoreGraphics APIs
+	on the reference platform; rather, they are part of the ImageIO
+	framework and should be installed on the system as such.
+
+	However, simply transferring these two APIs from OpalGraphics into a new
+	"OpalImage" subproject is not so easy, since they have developed in many
+	ways a symbiotic relationship inside the library.
+
+	As a workaround, a GNUmakefile.postamble file has been added to
+	OpalGraphics which takes care of installing ImageIO headers properly.
+
+2017-08-04  Daniel Ferreira <dtf@stanford.edu>
+
+	* Source/OpalText/GNUmakefile:	
+	A mistake in the addition of SFNTLayoutTypes.h omitted an entry in the
+	project's GNUmakefile for it to be installed. This fixes the issue.
+
 2017-07-26  Daniel Ferreira <dtf@stanford.edu>
 
 	* Headers/CoreText/CoreText.h

--- a/Headers/ImageIO/ImageIO.h
+++ b/Headers/ImageIO/ImageIO.h
@@ -1,0 +1,28 @@
+/** <title>ImageIO</title>
+
+   Copyright (C) 2017 Free Software Foundation, Inc.
+   Author: Daniel Ferreira <dtf@stanford.edu>
+    
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+   
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+   
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+   */
+
+#ifndef OPAL_ImageIO_h
+#define OPAL_ImageIO_h
+
+#include <ImageIO/ImageIOBase.h>
+#include <ImageIO/CGImageDestination.h>
+#include <ImageIO/CGImageSource.h>
+
+#endif

--- a/Headers/ImageIO/ImageIOBase.h
+++ b/Headers/ImageIO/ImageIOBase.h
@@ -1,0 +1,61 @@
+/** <title>ImageIOBase</title>
+
+   Copyright (C) 2017 Free Software Foundation, Inc.
+   Author: Daniel Ferreira <dtf@stanford.edu>
+    
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+   
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+   
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+   */
+
+#ifndef OPAL_ImageIOBase_h
+#define OPAL_ImageIOBase_h
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#define IMAGEIO_AVAILABLE_STARTING(_mac,_iphone)
+#define IMAGEIO_AVAILABLE_BUT_DEPRECATED(_mac,_macDep,_iphone,_iphoneDep)
+
+#ifndef IMAGEIO_EXTERN
+#if defined(__MINGW32__)
+
+#ifdef __cplusplus
+#define IMAGEIO_EXTERN extern "C" __declspec(dllexport)
+#else
+#define IMAGEIO_EXTERN extern __declspec(dllexport)
+#endif
+
+#else
+
+#if defined(__cplusplus)
+#define IMAGEIO_EXTERN extern "C"
+#else
+#define IMAGEIO_EXTERN extern
+#endif
+
+#endif
+#endif
+
+#if !defined(IMAGEIO_EXTERN_C_BEGIN)
+#ifdef __cplusplus
+#define IMAGEIO_EXTERN_C_BEGIN extern "C" {
+#define IMAGEIO_EXTERN_C_END }
+#else
+#define IMAGEIO_EXTERN_C_BEGIN
+#define IMAGEIO_EXTERN_C_END
+#endif
+#endif
+
+#define IIO_HAS_IOSURFACE 0
+
+#endif

--- a/Source/OpalGraphics/GNUmakefile.postamble
+++ b/Source/OpalGraphics/GNUmakefile.postamble
@@ -1,0 +1,6 @@
+# GNUmakefile.postamble
+
+after-install::
+	cp -r ../../Headers/ImageIO $(shell gnustep-config --variable=GNUSTEP_SYSTEM_HEADERS)/ImageIO
+	cp ../../Headers/CoreGraphics/CGImageSource.h $(shell gnustep-config --variable=GNUSTEP_SYSTEM_HEADERS)/ImageIO
+	cp ../../Headers/CoreGraphics/CGImageDestination.h $(shell gnustep-config --variable=GNUSTEP_SYSTEM_HEADERS)/ImageIO

--- a/Source/OpalText/GNUmakefile
+++ b/Source/OpalText/GNUmakefile
@@ -29,7 +29,8 @@ $(SUBPROJECT_NAME)_HEADER_FILES = \
 	CTRun.h\
 	CTStringAttributes.h\
 	CTTextTab.h\
-	CTTypesetter.h
+	CTTypesetter.h\
+	SFNTLayoutTypes.h
 
 ADDITIONAL_OBJCFLAGS += -Wall -g -O0 -std=gnu99 -DINTERNAL_BUILD_OBJC
 ADDITIONAL_CPPFLAGS += $(shell pkg-config --cflags cairo)


### PR DESCRIPTION
This commit fixes a small issue left behind from #5 and makes use of a temporary workaround to install ImageIO headers supplied by Opal.