### PR TITLE
Add extern keyword to fix multiple definition errors

### DIFF
--- a/Source/OpalText/OPFont.h
+++ b/Source/OpalText/OPFont.h
@@ -72,7 +72,7 @@ typedef enum _OPFontRenderingMode
   OPFontAntialiasedIntegerAdvancementsRenderingMode
 } OPFontRenderingMode;
 
-const CGFloat *OPFontIdentityMatrix;
+extern const CGFloat *OPFontIdentityMatrix;
 
 
 /**

--- a/Source/OpalText/OPFontDescriptor.h
+++ b/Source/OpalText/OPFontDescriptor.h
@@ -74,34 +74,33 @@ enum _OPFontTrait
 };
 
 // FIXME: Document these with the value type
-
-NSString *OPFontFamilyAttribute;
-NSString *OPFontNameAttribute;
-NSString *OPFontFaceAttribute;
-NSString *OPFontSizeAttribute; 
-NSString *OPFontVisibleNameAttribute; 
-NSString *OPFontColorAttribute;
+extern NSString *OPFontFamilyAttribute;
+extern NSString *OPFontNameAttribute;
+extern NSString *OPFontFaceAttribute;
+extern NSString *OPFontSizeAttribute; 
+extern NSString *OPFontVisibleNameAttribute; 
+extern NSString *OPFontColorAttribute;
 /**
  * NOTE: OPFontMatrixAttribute is a NSAffineTransform, unlike kCTFontMatrixAttribute which 
  * is an NSData containing a CGAffineTransform struct.
  */
-NSString *OPFontMatrixAttribute;
-NSString *OPFontVariationAttribute;
-NSString *OPFontCharacterSetAttribute;
-NSString *OPFontCascadeListAttribute;
-NSString *OPFontTraitsAttribute;
-NSString *OPFontFixedAdvanceAttribute;
+extern NSString *OPFontMatrixAttribute;
+extern NSString *OPFontVariationAttribute;
+extern NSString *OPFontCharacterSetAttribute;
+extern NSString *OPFontCascadeListAttribute;
+extern NSString *OPFontTraitsAttribute;
+extern NSString *OPFontFixedAdvanceAttribute;
 
-NSString *OPFontSymbolicTrait;
-NSString *OPFontWeightTrait;
-NSString *OPFontWidthTrait;
-NSString *OPFontSlantTrait;
+extern NSString *OPFontSymbolicTrait;
+extern NSString *OPFontWeightTrait;
+extern NSString *OPFontWidthTrait;
+extern NSString *OPFontSlantTrait;
 
-NSString *OPFontVariationAxisIdentifierKey;
-NSString *OPFontVariationAxisMinimumValueKey;
-NSString *OPFontVariationAxisMaximumValueKey;
-NSString *OPFontVariationAxisDefaultValueKey;
-NSString *OPFontVariationAxisNameKey;
+extern NSString *OPFontVariationAxisIdentifierKey;
+extern NSString *OPFontVariationAxisMinimumValueKey;
+extern NSString *OPFontVariationAxisMaximumValueKey;
+extern NSString *OPFontVariationAxisDefaultValueKey;
+extern NSString *OPFontVariationAxisNameKey;
 
 @interface OPFontDescriptor : NSObject <NSCopying>
 {

--- a/Source/OpalText/OPFontDescriptor.m
+++ b/Source/OpalText/OPFontDescriptor.m
@@ -39,6 +39,30 @@
 #include <CoreText/CTFontDescriptor.h>
 #import "OPFontDescriptor.h"
 
+// FIXME: Duplicate code, copied from libs-gui externs.m
+NSString *OPFontFamilyAttribute = @"NSFontFamilyAttribute";
+NSString *OPFontNameAttribute = @"NSFontNameAttribute";
+NSString *OPFontFaceAttribute = @"NSFontFaceAttribute";
+NSString *OPFontSizeAttribute = @"NSFontSizeAttribute"; 
+NSString *OPFontVisibleNameAttribute = @"NSFontVisibleNameAttribute"; 
+NSString *OPFontColorAttribute = @"NSFontColorAttribute";
+NSString *OPFontMatrixAttribute = @"NSFontMatrixAttribute";
+NSString *OPFontVariationAttribute = @"NSCTFontVariationAttribute";
+NSString *OPFontCharacterSetAttribute = @"NSCTFontCharacterSetAttribute";
+NSString *OPFontCascadeListAttribute = @"NSCTFontCascadeListAttribute";
+NSString *OPFontTraitsAttribute = @"NSCTFontTraitsAttribute";
+NSString *OPFontFixedAdvanceAttribute = @"NSCTFontFixedAdvanceAttribute";
+
+NSString *OPFontSymbolicTrait = @"NSCTFontSymbolicTrait";
+NSString *OPFontWeightTrait = @"NSCTFontWeightTrait";
+NSString *OPFontWidthTrait = @"NSCTFontProportionTrait";
+NSString *OPFontSlantTrait = @"NSCTFontSlantTrait";
+
+NSString *OPFontVariationAxisIdentifierKey = @"NSCTFontVariationAxisIdentifier";
+NSString *OPFontVariationAxisMinimumValueKey = @"NSCTFontVariationAxisMinimumValue";
+NSString *OPFontVariationAxisMaximumValueKey = @"NSCTFontVariationAxisMaximumValue";
+NSString *OPFontVariationAxisDefaultValueKey = @"NSCTFontVariationAxisDefaultValue";
+NSString *OPFontVariationAxisNameKey = @"NSCTFontVariationAxisName";
 
 @implementation OPFontDescriptor
 


### PR DESCRIPTION
This PR is intended to get libs-opal into a state where it can be compiled successfully. It adds extern keyword to fix multiple definition errors related to OPFontDescriptor globals https://github.com/gnustep/libs-opal/issues/8.  I wasn't sure whether I should include something similar to APPKIT_EXTERN, I can add this if required. I've also added definitions for these variables from `extern.m` to avoid crash at runtime.

I was able to get most of the test applications running successfully.
Notes about tests:
`images` crashes due to 'invalid' images
`textlayout` ran but didn't look good
