### PR TITLE
fix(build): guard CG type redefinitions against libs-base CFCGTypes.h

### DIFF
--- a/Headers/CoreGraphics/CGAffineTransform.h
+++ b/Headers/CoreGraphics/CGAffineTransform.h
@@ -34,6 +34,11 @@ extern "C" {
 
 /* Data Types */
 
+/* libs-base's CFCGTypes.h (included via NSGeometry.h) already declares
+ * struct CGAffineTransform with the same field layout. Redeclaring here
+ * collides.
+ */
+#ifndef _CFCGTypes_h_GNUSTEP_BASE_INCLUDE
 typedef struct CGAffineTransform
 {
   CGFloat a;
@@ -43,6 +48,7 @@ typedef struct CGAffineTransform
   CGFloat tx;
   CGFloat ty;
 } CGAffineTransform;
+#endif /* _CFCGTypes_h_GNUSTEP_BASE_INCLUDE */
 
 /* Constants */
 

--- a/Headers/CoreGraphics/CGGeometry.h
+++ b/Headers/CoreGraphics/CGGeometry.h
@@ -33,6 +33,13 @@
 extern "C" {
 #endif
 
+/* When libs-base's CFCGTypes.h is available (included via NSGeometry.h)
+ * it already defines CGPoint / CGSize / CGRect and the anonymous enum that
+ * declares CGRectMinXEdge ... CGRectMaxYEdge. Redefining those is a hard
+ * error on clang/gcc. CFCGTypes.h does NOT provide a `CGRectEdge` typedef,
+ * so we always emit that.
+ */
+#ifndef _CFCGTypes_h_GNUSTEP_BASE_INCLUDE
 typedef NSPoint CGPoint;
 typedef NSSize CGSize;
 typedef NSRect CGRect;
@@ -46,6 +53,7 @@ enum
   CGRectMaxXEdge = 2,
   CGRectMaxYEdge = 3
 };
+#endif /* _CFCGTypes_h_GNUSTEP_BASE_INCLUDE */
 typedef int CGRectEdge;
 
 /** Point at 0,0 */
@@ -329,10 +337,16 @@ OP_GEOM_SCOPE CGRect CGRectMake(CGFloat x, CGFloat y, CGFloat width, CGFloat hei
   return rect;
 }
 
+#ifndef _CFCGTypes_h_GNUSTEP_BASE_INCLUDE
+/* libs-base's NSGeometry.h already provides NSRectToCGRect / NSRectFromCGRect
+ * / NSPointToCGPoint / NSPointFromCGPoint / NSSizeToCGSize / NSSizeFromCGSize
+ * as inline functions when CFCGTypes.h has been pulled in. Defining them a
+ * second time collides at the translation-unit level.
+ */
 OP_GEOM_SCOPE CGRect NSRectToCGRect(NSRect rect)
 {
   CGRect cgrect;
-  
+
   cgrect.origin.x = rect.origin.x;
   cgrect.origin.y = rect.origin.y;
   cgrect.size.width = rect.size.width;
@@ -343,7 +357,7 @@ OP_GEOM_SCOPE CGRect NSRectToCGRect(NSRect rect)
 OP_GEOM_SCOPE NSRect NSRectFromCGRect(CGRect rect)
 {
   NSRect nsrect;
-  
+
   nsrect.origin.x = rect.origin.x;
   nsrect.origin.y = rect.origin.y;
   nsrect.size.width = rect.size.width;
@@ -386,6 +400,7 @@ OP_GEOM_SCOPE CGSize NSSizeToCGSize(NSSize size)
   cgsize.height = size.height;
   return cgsize;
 }
+#endif /* _CFCGTypes_h_GNUSTEP_BASE_INCLUDE */
 
 OP_GEOM_SCOPE CGRect CGRectStandardize(CGRect rect)
 {


### PR DESCRIPTION
## Problem

Building libs-opal on Linux against a modern libs-base install fails with:

```
../../Headers/CoreGraphics/CGGeometry.h:44:3: error: redefinition of enumerator 'CGRectMinXEdge'
../../Headers/CoreGraphics/CGGeometry.h:332:22: error: redefinition of 'NSRectToCGRect'
../../Headers/CoreGraphics/CGAffineTransform.h:37:16: error: redefinition of 'CGAffineTransform'
... (12 errors total)
```

Root cause: `libs-base/Headers/CoreFoundation/CFCGTypes.h` (transitively included via `<Foundation/NSGeometry.h>`) already declares `CGPoint`, `CGSize`, `CGRect`, the `CGRectMinXEdge..CGRectMaxYEdge` anonymous enum, and `struct CGAffineTransform`. libs-opal's own headers then redeclare the same types unconditionally, which is a hard error under clang and gcc.

The `NSRect`/`NSPoint`/`NSSize` ↔ CG conversion helpers (`NSRectToCGRect`, `NSRectFromCGRect`, `NSPointToCGPoint`, `NSPointFromCGPoint`, `NSSizeToCGSize`, `NSSizeFromCGSize`) are also provided by `NSGeometry.h` when CFCGTypes.h is present, and collide for the same reason.

## Fix

Detect libs-base's CFCGTypes.h via its own include guard `_CFCGTypes_h_GNUSTEP_BASE_INCLUDE` and skip the duplicate declarations in `CGGeometry.h` and `CGAffineTransform.h`.

`CGRectEdge` itself is **not** provided by CFCGTypes.h (only the enum values are), so the `typedef int CGRectEdge;` is always emitted — otherwise CGGeometry.h line 140 would reference an undeclared type.

## Environment

- Ubuntu 24.04, clang 18.1.3
- libs-base HEAD installed to `/usr/local`
- libs-opal built via `make CC=clang CXX=clang++`

## Platform impact

- **Linux/clang:** now builds cleanly (0 errors, all existing warnings unchanged).
- **macOS:** untouched — `__APPLE__` path defines its own CG types and doesn't include CFCGTypes.h.
- **Windows/MSYS2:** untouched — current MSYS2 clang builds don't expose CFCGTypes.h through this path either. No-op on that environment.

## Test plan

- [x] Clean build of libs-opal against installed libs-base on Ubuntu 24.04 + clang 18.1.3
- [x] libs-quartzcore (downstream consumer) still builds against the patched libs-opal
- [ ] macOS spot-check (I don't have a Mac to verify locally; the change is conditional on `_CFCGTypes_h_GNUSTEP_BASE_INCLUDE` which isn't defined under Apple's CoreGraphics)