### PR TITLE
Fix build against current GNUstep core (libs-corebase, libs-quartzcore)

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        path: libs-opal
     - name: Prepare
       run: |
         sudo apt-get update
@@ -15,11 +17,12 @@ jobs:
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/gnustep/tools-scripts/master/gnustep-web-install)"
     - name: Install GNUstep Corebase
       run: |
-        cd gnustep/libs-corebase 
+        cd gnustep/libs-corebase
         ./configure
         . /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
         sudo PATH=$PATH make install
     - name: Compile lib-opal
+      working-directory: libs-opal
       run: |
         . /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
         make distclean

--- a/Headers/CoreGraphics/CGAffineTransform.h
+++ b/Headers/CoreGraphics/CGAffineTransform.h
@@ -34,6 +34,7 @@ extern "C" {
 
 /* Data Types */
 
+#ifndef CF_DEFINES_CG_TYPES
 typedef struct CGAffineTransform
 {
   CGFloat a;
@@ -43,6 +44,7 @@ typedef struct CGAffineTransform
   CGFloat tx;
   CGFloat ty;
 } CGAffineTransform;
+#endif /* CF_DEFINES_CG_TYPES */
 
 /* Constants */
 

--- a/Headers/CoreGraphics/CGBase.h
+++ b/Headers/CoreGraphics/CGBase.h
@@ -32,6 +32,12 @@
 // for off_t
 #include <sys/types.h>
 
+// Import Foundation first in ObjC mode so CoreFoundation.h inline functions
+// can resolve NSObject method signatures (-hash, -isEqual:, etc.)
+#ifdef __OBJC__
+#import <Foundation/NSObject.h>
+#endif
+
 #import <CoreFoundation/CoreFoundation.h>
 
 /* Missing CoreFoundation types not provided by GNUstep CoreFoundation */

--- a/Headers/CoreGraphics/CGBase.h
+++ b/Headers/CoreGraphics/CGBase.h
@@ -34,6 +34,38 @@
 
 #import <CoreFoundation/CoreFoundation.h>
 
+/* Missing CoreFoundation types not provided by GNUstep CoreFoundation */
+#ifndef CFNUMBER_DEFINED
+#define CFNUMBER_DEFINED
+typedef const void * CFNumberRef;
+#endif
+#ifndef CFSET_DEFINED
+#define CFSET_DEFINED
+typedef const void * CFSetRef;
+typedef void * CFMutableSetRef;
+#endif
+#ifndef CFDATE_DEFINED
+#define CFDATE_DEFINED
+typedef const void * CFDateRef;
+#endif
+#ifndef CF_ENUM_COMPARISON_RESULT
+#define CF_ENUM_COMPARISON_RESULT
+typedef CFIndex CFComparisonResult;
+#endif
+#ifndef CFCHARACTERSET_DEFINED
+#define CFCHARACTERSET_DEFINED
+typedef const void * CFCharacterSetRef;
+#endif
+#ifndef CFATTRIBUTEDSTRING_DEFINED
+#define CFATTRIBUTEDSTRING_DEFINED
+typedef const void * CFAttributedStringRef;
+typedef void * CFMutableAttributedStringRef;
+#endif
+#ifndef CFERROR_DEFINED
+#define CFERROR_DEFINED
+typedef const void * CFErrorRef;
+#endif
+
 // Note: GNUstep Foundation defines CGFloat
 #ifdef __OBJC__
 #import <Foundation/Foundation.h>

--- a/Headers/CoreGraphics/CGBase.h
+++ b/Headers/CoreGraphics/CGBase.h
@@ -40,35 +40,18 @@
 
 #import <CoreFoundation/CoreFoundation.h>
 
-/* Missing CoreFoundation types not provided by GNUstep CoreFoundation */
-#ifndef CFNUMBER_DEFINED
-#define CFNUMBER_DEFINED
+/* Fallback CF type stubs - only needed if libs-corebase is not installed.
+   When libs-corebase is present, CoreFoundation.h already defines these. */
+#ifndef __COREFOUNDATION_CFNUMBER_H__
+/* libs-corebase not available, define stub types */
 typedef const void * CFNumberRef;
-#endif
-#ifndef CFSET_DEFINED
-#define CFSET_DEFINED
 typedef const void * CFSetRef;
 typedef void * CFMutableSetRef;
-#endif
-#ifndef CFDATE_DEFINED
-#define CFDATE_DEFINED
 typedef const void * CFDateRef;
-#endif
-#ifndef CF_ENUM_COMPARISON_RESULT
-#define CF_ENUM_COMPARISON_RESULT
 typedef CFIndex CFComparisonResult;
-#endif
-#ifndef CFCHARACTERSET_DEFINED
-#define CFCHARACTERSET_DEFINED
 typedef const void * CFCharacterSetRef;
-#endif
-#ifndef CFATTRIBUTEDSTRING_DEFINED
-#define CFATTRIBUTEDSTRING_DEFINED
 typedef const void * CFAttributedStringRef;
 typedef void * CFMutableAttributedStringRef;
-#endif
-#ifndef CFERROR_DEFINED
-#define CFERROR_DEFINED
 typedef const void * CFErrorRef;
 #endif
 

--- a/Headers/CoreGraphics/CGGeometry.h
+++ b/Headers/CoreGraphics/CGGeometry.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+#ifndef CF_DEFINES_CG_TYPES
 typedef NSPoint CGPoint;
 typedef NSSize CGSize;
 typedef NSRect CGRect;
@@ -46,6 +47,7 @@ enum
   CGRectMaxXEdge = 2,
   CGRectMaxYEdge = 3
 };
+#endif /* CF_DEFINES_CG_TYPES */
 typedef int CGRectEdge;
 
 /** Point at 0,0 */
@@ -90,12 +92,14 @@ OP_GEOM_SCOPE CGSize CGSizeMake(CGFloat width, CGFloat height) OP_GEOM_ATTR;
 /** Returns a CGRect having point of origin (x, y) and size (width, height). */
 OP_GEOM_SCOPE CGRect CGRectMake(CGFloat x, CGFloat y, CGFloat width, CGFloat height) OP_GEOM_ATTR;
 
+#ifndef CF_DEFINES_CG_TYPES
 OP_GEOM_SCOPE CGRect NSRectToCGRect(NSRect rect);
 OP_GEOM_SCOPE NSRect NSRectFromCGRect(CGRect rect);
 OP_GEOM_SCOPE CGPoint NSPointToCGPoint(NSPoint point);
 OP_GEOM_SCOPE NSPoint NSPointFromCGPoint(CGPoint point);
 OP_GEOM_SCOPE NSSize NSSizeFromCGSize(CGSize size);
 OP_GEOM_SCOPE CGSize NSSizeToCGSize(NSSize size);
+#endif /* CF_DEFINES_CG_TYPES */
 
 /** Returns an equivalent rect which has positive width and heght. */
 OP_GEOM_SCOPE CGRect CGRectStandardize(CGRect rect) OP_GEOM_ATTR;
@@ -329,10 +333,11 @@ OP_GEOM_SCOPE CGRect CGRectMake(CGFloat x, CGFloat y, CGFloat width, CGFloat hei
   return rect;
 }
 
+#ifndef CF_DEFINES_CG_TYPES
 OP_GEOM_SCOPE CGRect NSRectToCGRect(NSRect rect)
 {
   CGRect cgrect;
-  
+
   cgrect.origin.x = rect.origin.x;
   cgrect.origin.y = rect.origin.y;
   cgrect.size.width = rect.size.width;
@@ -343,7 +348,7 @@ OP_GEOM_SCOPE CGRect NSRectToCGRect(NSRect rect)
 OP_GEOM_SCOPE NSRect NSRectFromCGRect(CGRect rect)
 {
   NSRect nsrect;
-  
+
   nsrect.origin.x = rect.origin.x;
   nsrect.origin.y = rect.origin.y;
   nsrect.size.width = rect.size.width;
@@ -386,6 +391,7 @@ OP_GEOM_SCOPE CGSize NSSizeToCGSize(NSSize size)
   cgsize.height = size.height;
   return cgsize;
 }
+#endif /* CF_DEFINES_CG_TYPES */
 
 OP_GEOM_SCOPE CGRect CGRectStandardize(CGRect rect)
 {

--- a/Source/OpalGraphics/GNUmakefile
+++ b/Source/OpalGraphics/GNUmakefile
@@ -47,7 +47,7 @@ $(SUBPROJECT_NAME)_HEADER_FILES = \
 	CGEvent.h \
 	CGEventType.h \
 
-ADDITIONAL_OBJCFLAGS += -Wall -g -O0 -std=gnu99 -DINTERNAL_BUILD_OBJC
+ADDITIONAL_OBJCFLAGS += -Wall -g -O0 -std=gnu99 -DINTERNAL_BUILD_OBJC -Wno-error=int-conversion
 ADDITIONAL_CPPFLAGS += $(shell pkg-config --cflags cairo)
 ADDITIONAL_CPPFLAGS += $(shell pkg-config --cflags lcms2)
 

--- a/Source/OpalText/GNUmakefile
+++ b/Source/OpalText/GNUmakefile
@@ -32,7 +32,7 @@ $(SUBPROJECT_NAME)_HEADER_FILES = \
 	CTTypesetter.h\
 	SFNTLayoutTypes.h
 
-ADDITIONAL_OBJCFLAGS += -Wall -g -O0 -std=gnu99 -DINTERNAL_BUILD_OBJC
+ADDITIONAL_OBJCFLAGS += -Wall -g -O0 -std=gnu99 -DINTERNAL_BUILD_OBJC -Wno-error=int-conversion
 ADDITIONAL_CPPFLAGS += $(shell pkg-config --cflags cairo)
 
 ifneq ($(GNUSTEP_TARGET_OS), mingw32)

--- a/Tests/GNUmakefile
+++ b/Tests/GNUmakefile
@@ -34,7 +34,7 @@ else
 ADDITIONAL_OBJC_LIBS += -lgdi32
 endif
 
-ADDITIONAL_OBJCFLAGS += -Wall -g -O0 -std=gnu99
+ADDITIONAL_OBJCFLAGS += -Wall -g -O0 -std=gnu99 -Wno-error=int-conversion
 ADDITIONAL_CFLAGS += -Wall -g -O0 -std=gnu99
 ADDITIONAL_LDFLAGS += -L../Source/obj 
 ADDITIONAL_TOOL_LIBS = -lopal


### PR DESCRIPTION
  ## Summary                                                      
                                              
  Recent GNUstep core libraries (libs-corebase, libs-quartzcore) now declare
  the Core Graphics types (`CGPoint`, `CGSize`, `CGRect`, `CGAffineTransform`,
  etc.) themselves. Before this PR, libs-opal unconditionally redeclared the                                                                              
  same types, causing duplicate-definition build failures when libs-opal is
  built alongside current libs-corebase or when libs-quartzcore is pulled in.                                                                             
                                                                                                                                                          
  This also adjusts a couple of compiler flags so the current                                                                                             
  clang/gcc defaults (stricter `-Werror=int-conversion`) don't break the build.                                                                           
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  - `Headers/CoreGraphics/CGBase.h` — import `Foundation/NSObject.h` first                                                                                
    in ObjC mode so CoreFoundation inline functions can resolve NSObject
    methods; add fallback `CF*` typedef stubs for builds without                                                                                          
    libs-corebase (guarded by `__COREFOUNDATION_CFNUMBER_H__`).                                                                                           
  - `Headers/CoreGraphics/CGGeometry.h` and `CGAffineTransform.h` — guard
    the CG type declarations and `NS*`↔`CG*` bridge helpers with                                                                                          
    `#ifndef CF_DEFINES_CG_TYPES` so they're skipped when CoreFoundation                                                                                  
    already provides them.                                                                                                                                
  - `Source/OpalGraphics/GNUmakefile`, `Source/OpalText/GNUmakefile`,                                                                                     
    `Tests/GNUmakefile` — add `-Wno-error=int-conversion` so the build                                                                                    
    doesn't fail on modern toolchains.                                                                                                                    
                                                                                                                                                          
  ## Compatibility                                                                                                                                        
                                                                                                                                                          
  - **With current libs-corebase / libs-quartzcore**: types come from                                                                                     
    CoreFoundation; the guarded blocks are skipped; libs-opal builds cleanly.                                                                             
  - **Without libs-corebase**: the fallback stub typedefs kick in and the
    original CG type declarations are used, same as before.                                                                                               
                                              
  ## Testing                                                                                                                                              
                                                                                                                                                          
  Built cleanly against current GNUstep core on Devuan/Linux x86_64.                                                                                      
  Ran the existing test suite in `Tests/` (shapes, paths, gradients,                                                                                      
  shadows, images) — all render correctly.    