### PR TITLE
CGContext: avoid dereferencing a NULL context in the NULL-guard log

### DIFF
--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -817,8 +817,8 @@ static void fill_path(CGContextRef ctx, int eorule, int preserve)
     {
       NSLog(@"null %s%s%s in %s",
             !ctx ? "ctx" : "",
-            (!ctx && !ctx->add) ? " and " : "", 
-            !ctx->add ? "ctx->add" : "",
+            (ctx && !ctx->add) ? "ctx->add" : "",
+            "",
             __PRETTY_FUNCTION__);
       return;
     }
@@ -1085,8 +1085,8 @@ CGFloat OPContextGetAlpha(CGContextRef ctx)
     {
       NSLog(@"null %s%s%s in %s",
             !ctx ? "ctx" : "",
-            (!ctx && !ctx->add) ? " and " : "", 
-            !ctx->add ? "ctx->add" : "",
+            (ctx && !ctx->add) ? "ctx->add" : "",
+            "",
             __PRETTY_FUNCTION__);
       return 0;
     }
@@ -1147,8 +1147,8 @@ void CGContextSetFillColorWithColor(CGContextRef ctx, CGColorRef color)
     {
       NSLog(@"null %s%s%s in %s",
             !ctx ? "ctx" : "",
-            (!ctx && !ctx->add) ? " and " : "", 
-            !ctx->add ? "ctx->add" : "",
+            (ctx && !ctx->add) ? "ctx->add" : "",
+            "",
             __PRETTY_FUNCTION__);
       OPRESTORELOGGING()
       return;
@@ -1168,8 +1168,8 @@ void CGContextSetStrokeColorWithColor(CGContextRef ctx, CGColorRef color)
     {
       NSLog(@"null %s%s%s in %s",
             !ctx ? "ctx" : "",
-            (!ctx && !ctx->add) ? " and " : "", 
-            !ctx->add ? "ctx->add" : "",
+            (ctx && !ctx->add) ? "ctx->add" : "",
+            "",
             __PRETTY_FUNCTION__);
       OPRESTORELOGGING()
       return;
@@ -1189,8 +1189,8 @@ void CGContextSetAlpha(CGContextRef ctx, CGFloat alpha)
     {
       NSLog(@"null %s%s%s in %s", 
             !ctx ? "ctx" : "",
-            (!ctx && !ctx->add) ? " and " : "", 
-            !ctx->add ? "ctx->add" : "",
+            (ctx && !ctx->add) ? "ctx->add" : "",
+            "",
             __PRETTY_FUNCTION__);
       OPRESTORELOGGING()
       return;


### PR DESCRIPTION
## Summary

Several `CGContext` functions guard with `if (!ctx || !ctx->add)` and then log
which pointer was NULL. The diagnostic evaluated `!ctx->add` (and
`!ctx && !ctx->add`) **unconditionally**, so when `ctx` itself was NULL the log
dereferenced it — e.g. `CGContextFillPath(NULL)` crashed inside the very guard
meant to tolerate a NULL context. The pattern is repeated at five sites
(`fill_path`, `OPContextGetAlpha`, `CGContextSetFillColorWithColor`,
`CGContextSetStrokeColorWithColor`, `CGContextSetAlpha`).

## Fix

Only read `ctx->add` when `ctx` is non-NULL. The guard already guarantees
exactly one of the two is NULL, so the logged message is unchanged for the
reachable cases.

## Validation

Built `libopal` (clang, gnustep-2.0) and ran `CGContextFillPath(NULL)`,
`CGContextSetFillColorWithColor(NULL, NULL)`,
`CGContextSetStrokeColorWithColor(NULL, NULL)`, `CGContextSetAlpha(NULL, 0.5)`
under AddressSanitizer: each now logs `null ctx in …` and returns instead of
crashing.
