### PR TITLE
CGContext+GState: allocate the dash array as doubles, not bytes (heap overflow)

### DIFF
--- a/Source/OpalGraphics/CGContext+GState.m
+++ b/Source/OpalGraphics/CGContext+GState.m
@@ -85,7 +85,7 @@
   dashes_count = cairo_get_dash_count(aCairo);
   if (dashes_count > 0)
   {
-    dashes = malloc(dashes_count);
+    dashes = malloc(dashes_count * sizeof(double));
     
     if (dashes != NULL)
   	{


### PR DESCRIPTION
## Summary

`OpalGStateSnapshot -initWithContext:` snapshots the cairo dash array:

```c
double *dashes;
...
dashes = malloc(dashes_count);              /* bytes, not doubles */
if (dashes != NULL)
    cairo_get_dash(aCairo, dashes, &dashes_offset);   /* writes dashes_count doubles */
```

`dashes` is a `double *`, but the buffer is `malloc(dashes_count)` — one byte per
entry instead of `sizeof(double)`. `cairo_get_dash` then writes `dashes_count`
doubles into it, an 8× under-allocation and **heap buffer overflow** whenever a
dashed graphics state is snapshotted (e.g. via `OPContextCopyGState`).

## Fix

`malloc(dashes_count * sizeof(double))`.

## Validation

Built `libopal` (clang, gnustep-2.0). Set a 4-element dash pattern on a bitmap
context and called `OPContextCopyGState` under AddressSanitizer:
- **Before:** `heap-buffer-overflow WRITE of size 32` in `cairo_get_dash`,
  buffer allocated at `CGContext+GState.m:88`.
- **After:** clean.
