### PR TITLE
OPImageCodecTIFF: fix inverted type check that broke TIFF writing

### DIFF
--- a/Source/OpalGraphics/image/OPImageCodecTIFF.m
+++ b/Source/OpalGraphics/image/OPImageCodecTIFF.m
@@ -334,7 +334,7 @@ static void OPTIFFUnmapProc(thandle_t handle, tdata_t data, toff_t size)
 {
   self = [super init];
   
-  if ([type isEqualToString: @"public.tiff"] || count != 1)
+  if (![type isEqualToString: @"public.tiff"] || count != 1)
   {
     [self release];
     return nil;


### PR DESCRIPTION
## Summary

The TIFF image destination rejected its own type. `-initWithDataConsumer:type:count:options:` guarded with:

```objc
if ([type isEqualToString: @"public.tiff"] || count != 1)
{
    [self release];
    return nil;
}
```

so creating a destination for `"public.tiff"` — the only type this codec
handles (`+typeIdentifiers` returns exactly `public.tiff`) — always returned
nil. TIFF writing never worked.

## Fix

Negate the type test (`![type isEqualToString: @"public.tiff"]`), so the codec
rejects *other* types and a count other than 1.

## Validation

Built `libopal` (clang, gnustep-2.0) and called
`CGImageDestinationCreateWithData(data, CFSTR("public.tiff"), 1, NULL)`:
- **Before:** returns `NULL` (nil destination).
- **After:** returns a valid `CGImageDestinationRef`.
