### PR TITLE
Fix: CGAffineTransformIsIdentity checks for the identity, not any diagonal transform

### DIFF
--- a/Headers/CoreGraphics/CGAffineTransform.h
+++ b/Headers/CoreGraphics/CGAffineTransform.h
@@ -241,7 +241,7 @@ GS_AFTR_SCOPE bool CGAffineTransformEqualToTransform(CGAffineTransform t1, CGAff
 
 GS_AFTR_SCOPE bool CGAffineTransformIsIdentity(CGAffineTransform t)
 {
-  return t.a && !t.b && !t.c && t.d && !t.tx && !t.ty;
+  return t.a == 1 && t.b == 0 && t.c == 0 && t.d == 1 && t.tx == 0 && t.ty == 0;
 }
 
 GS_AFTR_SCOPE CGPoint CGPointApplyAffineTransform(


### PR DESCRIPTION
CGAffineTransformIsIdentity tested that the diagonal was non-zero rather than that it was one, so it returned true for any transform with zero off-diagonal and translation: a pure scale such as CGAffineTransformMakeScale(2, 3) was reported as the identity. Compare each component against the identity value instead.

This makes the hopeful assertion in the CGAffineTransform tests pass. The test is in #21, which should be merged first. Checked against Apple CoreGraphics on a macOS runner.