### PR TITLE
Fix: CGGeometry accessors, inset and containsPoint match CoreGraphics

### DIFF
--- a/Headers/CoreGraphics/CGGeometry.h
+++ b/Headers/CoreGraphics/CGGeometry.h
@@ -249,12 +249,12 @@ OP_GEOM_SCOPE CGFloat CGRectGetMaxY(CGRect rect)
 
 OP_GEOM_SCOPE CGFloat CGRectGetWidth(CGRect rect)
 {
-  return rect.size.width;
+  return (rect.size.width < 0) ? -rect.size.width : rect.size.width;
 }
 
 OP_GEOM_SCOPE CGFloat CGRectGetHeight(CGRect rect)
 {
-  return rect.size.height;
+  return (rect.size.height < 0) ? -rect.size.height : rect.size.height;
 }
 
 OP_GEOM_SCOPE int CGRectIsEmpty(CGRect rect)
@@ -279,8 +279,8 @@ OP_GEOM_SCOPE int CGRectContainsPoint(CGRect rect, CGPoint point)
   rect = CGRectStandardize(rect);
   return ((point.x >= rect.origin.x) &&
           (point.y >= rect.origin.y) &&
-          (point.x <= rect.origin.x + rect.size.width) &&
-          (point.y <= rect.origin.y + rect.size.height)) ? 1 : 0;
+          (point.x < rect.origin.x + rect.size.width) &&
+          (point.y < rect.origin.y + rect.size.height)) ? 1 : 0;
 }
 
 OP_GEOM_SCOPE int CGRectEqualToRect(CGRect rect1, CGRect rect2)
@@ -420,6 +420,8 @@ OP_GEOM_SCOPE CGRect CGRectInset(CGRect rect, CGFloat dx, CGFloat dy)
   rect.origin.y += dy;
   rect.size.width -= (2 * dx);
   rect.size.height -= (2 * dy);
+  if (rect.size.width < 0 || rect.size.height < 0)
+    return CGRectNull;
   return rect;
 }
 


### PR DESCRIPTION
Three CGGeometry functions diverge from CoreGraphics, all checked against Apple CoreGraphics on a macOS runner:

- CGRectGetWidth and CGRectGetHeight returned the raw size, so a rect with a negative size reported a negative width or height. Return the magnitude, as the other accessors already standardize.
- CGRectInset returned a rect with a negative size when the inset exceeded half the rect. Return the null rect in that case.
- CGRectContainsPoint used <= on the far edges, so it reported points on the max edge as contained. The max edge is outside the rect.

These make the corresponding hopeful assertions in the CGGeometry tests (#24) pass. #24 depends on the Tests/opal scaffolding in #21, so #21 should be merged first.