### PR TITLE
Fix: CGColor counts alpha in the component count and compares equal colours

### DIFF
--- a/Source/OpalGraphics/CGColor.m
+++ b/Source/OpalGraphics/CGColor.m
@@ -76,7 +76,8 @@ static CGColorRef _clearColor;
   int nc = CGColorSpaceGetNumberOfComponents(self->cspace);
 
   if (![self->cspace isEqual: otherColor->cspace]) return NO;
-  if (![self->pattern isEqual: otherColor->pattern]) return NO;
+  if (self->pattern != otherColor->pattern
+      && ![self->pattern isEqual: otherColor->pattern]) return NO;
   
   for (int i = 0; i <= nc; i++) {
     if (self->comps[i] != otherColor->comps[i])
@@ -272,7 +273,7 @@ CGColorRef CGColorGetConstantColor(CFStringRef name)
 
 size_t CGColorGetNumberOfComponents(CGColorRef clr)
 {
-  return CGColorSpaceGetNumberOfComponents(clr->cspace);
+  return CGColorSpaceGetNumberOfComponents(clr->cspace) + 1;
 }
 
 CGPatternRef CGColorGetPattern(CGColorRef clr)


### PR DESCRIPTION
Two bugs in CGColor diverge from CoreGraphics, checked against Apple CoreGraphics on a macOS runner:

- CGColorGetNumberOfComponents returned the colour space component count without alpha, so a generic RGB colour reported 3 instead of 4 (gray 1 instead of 2, CMYK 4 instead of 5). Count the alpha component, as CoreGraphics does.
- CGColorEqualToColor compared the patterns with -isEqual:, but for patternless colours that is [nil isEqual: nil], which is NO, so it returned false for every non-pattern colour, including a colour and its own copy. Skip the pattern comparison when both patterns are nil.

These make the corresponding hopeful checks in the CGColor tests (#25) pass.