### PR TITLE
Fix: CGPathGetCurrentPoint returns the subpath start after a close

### DIFF
--- a/Source/OpalGraphics/CGPath.m
+++ b/Source/OpalGraphics/CGPath.m
@@ -180,38 +180,33 @@ CGPoint CGPathGetCurrentPoint(CGPathRef path)
 
   NSUInteger count = [path count];
   CGPoint points[3];
+  CGPathElementType type = [path elementTypeAtIndex: count - 1 points: points];
 
-  // A closed subpath leaves the current point at the start of that subpath,
-  // which is its most recent move-to.
-  if ([path elementTypeAtIndex: count - 1 points: points]
-        == kCGPathElementCloseSubpath)
+  switch (type)
   {
-    for (NSUInteger i = count - 1; i < count; i--)
+    case kCGPathElementMoveToPoint:
+    case kCGPathElementAddLineToPoint:
+      return points[0];
+    case kCGPathElementAddQuadCurveToPoint:
+      return points[1];
+    case kCGPathElementAddCurveToPoint:
+      return points[2];
+    case kCGPathElementCloseSubpath:
     {
-      if ([path elementTypeAtIndex: i points: points]
-            == kCGPathElementMoveToPoint)
-        return points[0];
-    }
-    return CGPointZero;
-  }
+      // A closed subpath leaves the current point at the start of that
+      // subpath, which is its most recent move-to.
+      NSUInteger i = count - 1;
 
-  for (NSUInteger i=(count-1); i>=0 && i<count; i--)
-  {
-    CGPathElementType type =[path elementTypeAtIndex: i points: points];
-
-    switch (type)
-    {
-      case kCGPathElementMoveToPoint:
-      case kCGPathElementAddLineToPoint:
-        return points[0];
-      case kCGPathElementAddQuadCurveToPoint:
-        return points[1];
-      case kCGPathElementAddCurveToPoint:
-        return points[2];
-      case kCGPathElementCloseSubpath:
-      default:
-        break;
+      while (i-- > 0)
+      {
+        if ([path elementTypeAtIndex: i points: points]
+              == kCGPathElementMoveToPoint)
+          return points[0];
+      }
+      break;
     }
+    default:
+      break;
   }
   return CGPointZero;
 }

--- a/Source/OpalGraphics/CGPath.m
+++ b/Source/OpalGraphics/CGPath.m
@@ -179,10 +179,24 @@ CGPoint CGPathGetCurrentPoint(CGPathRef path)
   }
 
   NSUInteger count = [path count];
-  // FIXME: ugly loop
+  CGPoint points[3];
+
+  // A closed subpath leaves the current point at the start of that subpath,
+  // which is its most recent move-to.
+  if ([path elementTypeAtIndex: count - 1 points: points]
+        == kCGPathElementCloseSubpath)
+  {
+    for (NSUInteger i = count - 1; i < count; i--)
+    {
+      if ([path elementTypeAtIndex: i points: points]
+            == kCGPathElementMoveToPoint)
+        return points[0];
+    }
+    return CGPointZero;
+  }
+
   for (NSUInteger i=(count-1); i>=0 && i<count; i--)
   {
-    CGPoint points[3];
     CGPathElementType type =[path elementTypeAtIndex: i points: points];
 
     switch (type)


### PR DESCRIPTION
CGPathGetCurrentPoint returned the last corner of the path (the final line-to before the close) instead of the start of the subpath. After CGPathCloseSubpath, CoreGraphics leaves the current point at the start of the closed subpath, so after adding a rect the current point is the rect origin, not its last corner. When the last element is a close, return the subpath's move-to point.

Makes the current-point hopeful check in the CGPath tests (#27) pass. Checked against Apple CoreGraphics on a macOS runner. (The curve path-bounding-box divergence in #27 is left for a separate change.)