### PR TITLE
Fix: CGImageCreateWithImageInRect reports the cropped size

### DIFF
--- a/Source/OpalGraphics/CGImage.m
+++ b/Source/OpalGraphics/CGImage.m
@@ -483,11 +483,15 @@ bool CGImageIsMask(CGImageRef image)
 
 size_t CGImageGetWidth(CGImageRef image)
 {
+  if (!CGRectIsNull(image->crop))
+    return image->crop.size.width;
   return image->width;
 }
 
 size_t CGImageGetHeight(CGImageRef image)
 {
+  if (!CGRectIsNull(image->crop))
+    return image->crop.size.height;
   return image->height;
 }
 
@@ -558,8 +562,8 @@ cairo_surface_t *opal_CGImageGetSurfaceForImage(CGImageRef img, cairo_surface_t 
   if (NULL == img->surf)
   {
     cairo_surface_t *memSurf = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
-                                           CGImageGetWidth(img),
-                                           CGImageGetHeight(img));
+                                           img->width,
+                                           img->height);
     if (cairo_surface_status(memSurf) != CAIRO_STATUS_SUCCESS)
     {
       NSLog(@"Cairo error creating image\n");
@@ -569,8 +573,8 @@ cairo_surface_t *opal_CGImageGetSurfaceForImage(CGImageRef img, cairo_surface_t 
     cairo_surface_flush(memSurf); // going to modify the surface outside of cairo
 
     const unsigned char *srcData = OPDataProviderGetBytePointer(img->dp);
-    const size_t srcWidth = CGImageGetWidth(img);
-    const size_t srcHeight = CGImageGetHeight(img);
+    const size_t srcWidth = img->width;
+    const size_t srcHeight = img->height;
     const size_t srcBitsPerComponent = CGImageGetBitsPerComponent(img);
     const size_t srcBitsPerPixel = CGImageGetBitsPerPixel(img);
     const size_t srcBytesPerRow = CGImageGetBytesPerRow(img);


### PR DESCRIPTION
CGImageCreateWithImageInRect stored the crop rect but left the image's width and height at the full source size, so CGImageGetWidth and CGImageGetHeight reported the whole image rather than the crop (a 1x1 sub-image reported the parent's size). Drawing already honours the crop via the source rect, so only the reported size was wrong.

Return the crop size from CGImageGetWidth/CGImageGetHeight when a crop is set, and build the backing surface from the full source size (opal_CGImageGetSurfaceForImage) so the crop keeps being applied as the source rect at draw time. Verified by cropping the blue pixel out of a red|blue image: the sub-image reports 1x1 and draws blue.

Makes the sub-image size check in the CGImage tests (#30) pass. Checked against Apple CoreGraphics on a macOS runner.