### PR TITLE
Fix: strip alpha when encoding JPEG

### DIFF
--- a/Source/OpalGraphics/image/OPImageCodecJPEG.m
+++ b/Source/OpalGraphics/image/OPImageCodecJPEG.m
@@ -39,6 +39,7 @@
 #import "CGImageDestination-private.h"
 #import "CGDataProvider-private.h"
 #import "CGDataConsumer-private.h"
+#import "OPImageConversion.h"
 
 #include <jerror.h>
 #if defined(__MINGW32__)
@@ -682,16 +683,40 @@ static void gs_jpeg_memory_dest_destroy (j_compress_ptr cinfo)
 
     }*/
 
-    unsigned char *rowdata = malloc(row_stride);
+    /* libjpeg expects packed samples with one byte per colour component and
+       no alpha channel, but the image may carry alpha or a wider layout.  Read
+       each source row and convert it to that packed form before writing. */
+    const CGColorSpaceRef srcColorSpace = CGImageGetColorSpace(img);
+    const int srcBitsPerComponent = CGImageGetBitsPerComponent(img);
+    const int srcBitsPerPixel = CGImageGetBitsPerPixel(img);
+    const CGBitmapInfo srcBitmapInfo = CGImageGetBitmapInfo(img);
+    const CGColorRenderingIntent srcIntent = CGImageGetRenderingIntent(img);
+
+    const int dstComponents = cinfo.input_components;
+    const size_t dstBytesPerRow = dstComponents * cinfo.image_width;
+    const CGBitmapInfo dstBitmapInfo = kCGBitmapByteOrderDefault | kCGImageAlphaNone;
+
+    unsigned char *srcdata = malloc(row_stride);
+    unsigned char *rowdata = malloc(dstBytesPerRow);
     JSAMPROW row_pointer[1] = {rowdata};
     CGDataProviderRef dp = CGImageGetDataProvider(img);
     OPDataProviderRewind(dp);
     while (cinfo.next_scanline < cinfo.image_height)
     {
-      // FIXME: strip alpha
-      OPDataProviderGetBytes(dp, rowdata, row_stride);
+      OPDataProviderGetBytes(dp, srcdata, row_stride);
+
+      OPImageConvert(rowdata, srcdata,
+                     cinfo.image_width, 1,
+                     8, srcBitsPerComponent,
+                     8 * dstComponents, srcBitsPerPixel,
+                     dstBytesPerRow, row_stride,
+                     dstBitmapInfo, srcBitmapInfo,
+                     srcColorSpace, srcColorSpace,
+                     srcIntent);
+
       jpeg_write_scanlines(&cinfo, row_pointer, 1);
     }
+    free(srcdata);
     free(rowdata);
   
     jpeg_finish_compress(&cinfo);


### PR DESCRIPTION
The JPEG destination configured libjpeg for three-component RGB (or one-component grayscale) input, then handed it the image's raw rows. For the common RGBA case those rows carry a fourth alpha byte per pixel, so libjpeg read them as packed colour samples and every pixel after the first was taken from the wrong offset — the whole image came out discoloured. (A solid rgb(200,40,40) image, re-read by an independent decoder, came back as roughly rgb(130,77,35).)

Each source row is now converted to packed, alpha-free colour samples with OPImageConvert before being written, the same way the PNG destination normalises its rows. The decoder was already correct.

A regression test (a JPEG round-trip of a solid colour) is added in #35; it is marked hopeful there and passes once this is merged.