### PR TITLE
Feature: implement CGShading and CGFunction

### DIFF
--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -30,6 +30,8 @@
 
 #import "CGContext-private.h"
 #import "CGGradient-private.h"
+#import "CGShading-private.h"
+#import "CGFunction-private.h"
 #import "CGColor-private.h"
 #import "cairo/CairoFont.h"
 #import "OPLogging.h"
@@ -1524,10 +1526,86 @@ void CGContextDrawRadialGradient(
   OPRESTORELOGGING()
 }
 
+/* Sample the shading's function along the axis and add one Cairo colour stop
+   per sample, so that Cairo's linear interpolation approximates the (possibly
+   non-linear) function. */
+static void opal_AddShadingStops(cairo_pattern_t *pat, CGShadingRef shading)
+{
+  // FIXME: support other colorspaces by converting to deviceRGB
+  if (![CGColorSpaceCreateDeviceRGB() isEqual: OPShadingGetColorSpace(shading)])
+  {
+    NSLog(@"%s: Only DeviceRGB supported for shadings", __PRETTY_FUNCTION__);
+    return;
+  }
+
+  CGFunctionRef function = OPShadingGetFunction(shading);
+  const size_t numColorComps = 3; // DeviceRGB
+  const size_t rangeDim = OPFunctionGetRangeDimension(function);
+  const CGFloat *domain = OPFunctionGetDomain(function);
+  const CGFloat t0 = domain ? domain[0] : 0.0;
+  const CGFloat t1 = domain ? domain[1] : 1.0;
+
+  const int samples = 64;
+  for (int i = 0; i <= samples; i++)
+  {
+    CGFloat offset = (CGFloat)i / samples;
+    CGFloat in = t0 + offset * (t1 - t0);
+    CGFloat out[16] = {0};
+    OPFunctionEvaluate(function, &in, out);
+
+    /* A function whose range includes alpha supplies it last, otherwise the
+       colour is opaque. */
+    CGFloat alpha = (rangeDim > numColorComps) ? out[numColorComps] : 1.0;
+    cairo_pattern_add_color_stop_rgba(pat, offset, out[0], out[1], out[2], alpha);
+  }
+}
+
 void CGContextDrawShading(
   CGContextRef ctx,
-  CGShadingRef shading
-);
+  CGShadingRef shading)
+{
+  OPLOGCALL("ctx /*%p*/, <shading>", ctx)
+  if (!shading)
+  {
+    OPRESTORELOGGING()
+    return;
+  }
+
+  CGPoint start = OPShadingGetStart(shading);
+  CGPoint end = OPShadingGetEnd(shading);
+  cairo_pattern_t *pat;
+
+  if (OPShadingIsRadial(shading))
+  {
+    pat = cairo_pattern_create_radial(start.x, start.y,
+      OPShadingGetStartRadius(shading), end.x, end.y,
+      OPShadingGetEndRadius(shading));
+  }
+  else
+  {
+    pat = cairo_pattern_create_linear(start.x, start.y, end.x, end.y);
+  }
+
+  opal_AddShadingStops(pat, shading);
+
+  /* Without extension the area beyond the shading is left untouched; with it
+     the end colours fill outward.  Cairo only offers a symmetric choice, so
+     pad only when both ends extend. */
+  if (OPShadingGetExtendStart(shading) && OPShadingGetExtendEnd(shading))
+  {
+    cairo_pattern_set_extend(pat, CAIRO_EXTEND_PAD);
+  }
+  else
+  {
+    cairo_pattern_set_extend(pat, CAIRO_EXTEND_NONE);
+  }
+
+  cairo_set_source(ctx->ct, pat);
+  cairo_paint(ctx->ct);
+
+  cairo_pattern_destroy(pat);
+  OPRESTORELOGGING()
+}
 
 void CGContextSetFont(CGContextRef ctx, CGFontRef font)
 {

--- a/Source/OpalGraphics/CGFunction-private.h
+++ b/Source/OpalGraphics/CGFunction-private.h
@@ -1,0 +1,35 @@
+/** <title>CGFunction-private</title>
+
+ <abstract>C Interface to graphics drawing library</abstract>
+
+ Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+
+ Author: Eric Wasylishen
+ Date: June 2010
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "CoreGraphics/CGFunction.h"
+
+/* The number of input and output values the function takes. */
+size_t OPFunctionGetDomainDimension(CGFunctionRef function);
+size_t OPFunctionGetRangeDimension(CGFunctionRef function);
+
+/* The two-value-per-dimension input domain, or NULL if none was given. */
+const CGFloat *OPFunctionGetDomain(CGFunctionRef function);
+
+/* Evaluate the function, writing rangeDimension values to out. */
+void OPFunctionEvaluate(CGFunctionRef function, const CGFloat *in, CGFloat *out);

--- a/Source/OpalGraphics/CGFunction.m
+++ b/Source/OpalGraphics/CGFunction.m
@@ -1,41 +1,72 @@
 /** <title>CGFunction</title>
- 
+
  <abstract>C Interface to graphics drawing library</abstract>
- 
+
  Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
 
  Author: Eric Wasylishen
  Date: June 2010
-  
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 2.1 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #import <Foundation/NSObject.h>
-#include "CoreGraphics/CGFunction.h"
+#include <stdlib.h>
+#include <string.h>
+#include "CGFunction-private.h"
 
 @interface CGFunction : NSObject
 {
 @public
+  void *info;
+  size_t domainDimension;
+  size_t rangeDimension;
+  CGFloat *domain;
+  CGFloat *range;
+  CGFunctionCallbacks callbacks;
 }
 
 @end
 
 @implementation CGFunction
 
+- (void) dealloc
+{
+  if (callbacks.releaseInfo)
+    {
+      callbacks.releaseInfo(info);
+    }
+  free(domain);
+  free(range);
+  [super dealloc];
+}
+
 @end
 
+
+static CGFloat *copyPairs(const CGFloat *values, size_t dimension)
+{
+  if (values == NULL || dimension == 0)
+    {
+      return NULL;
+    }
+  size_t count = 2 * dimension;
+  CGFloat *copy = malloc(count * sizeof(CGFloat));
+  memcpy(copy, values, count * sizeof(CGFloat));
+  return copy;
+}
 
 CGFunctionRef CGFunctionCreate(
   void *info,
@@ -45,10 +76,22 @@ CGFunctionRef CGFunctionCreate(
   const CGFloat *range,
   const CGFunctionCallbacks *callbacks)
 {
-  CGFunctionRef func = [[CGFunction alloc] init];
-  
-  //FIXME
-  
+  CGFunction *func = [[CGFunction alloc] init];
+
+  func->info = info;
+  func->domainDimension = domainDimension;
+  func->rangeDimension = rangeDimension;
+  func->domain = copyPairs(domain, domainDimension);
+  func->range = copyPairs(range, rangeDimension);
+  if (callbacks)
+    {
+      func->callbacks = *callbacks;
+    }
+  else
+    {
+      memset(&func->callbacks, 0, sizeof(CGFunctionCallbacks));
+    }
+
   return func;
 }
 
@@ -60,4 +103,27 @@ CGFunctionRef CGFunctionRetain(CGFunctionRef function)
 void CGFunctionRelease(CGFunctionRef function)
 {
   [function release];
+}
+
+size_t OPFunctionGetDomainDimension(CGFunctionRef function)
+{
+  return function ? function->domainDimension : 0;
+}
+
+size_t OPFunctionGetRangeDimension(CGFunctionRef function)
+{
+  return function ? function->rangeDimension : 0;
+}
+
+const CGFloat *OPFunctionGetDomain(CGFunctionRef function)
+{
+  return function ? function->domain : NULL;
+}
+
+void OPFunctionEvaluate(CGFunctionRef function, const CGFloat *in, CGFloat *out)
+{
+  if (function && function->callbacks.evaluate)
+    {
+      function->callbacks.evaluate(function->info, in, out);
+    }
 }

--- a/Source/OpalGraphics/CGShading-private.h
+++ b/Source/OpalGraphics/CGShading-private.h
@@ -1,0 +1,43 @@
+/** <title>CGShading-private</title>
+
+ <abstract>C Interface to graphics drawing library</abstract>
+
+ Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+
+ Author: Eric Wasylishen
+ Date: June 2010
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "CoreGraphics/CGShading.h"
+
+/* YES for a radial shading, NO for an axial one. */
+bool OPShadingIsRadial(CGShadingRef shading);
+
+CGColorSpaceRef OPShadingGetColorSpace(CGShadingRef shading);
+CGFunctionRef OPShadingGetFunction(CGShadingRef shading);
+
+/* The axis endpoints (axial) or the two circle centres (radial). */
+CGPoint OPShadingGetStart(CGShadingRef shading);
+CGPoint OPShadingGetEnd(CGShadingRef shading);
+
+/* The two circle radii (radial only; zero for an axial shading). */
+CGFloat OPShadingGetStartRadius(CGShadingRef shading);
+CGFloat OPShadingGetEndRadius(CGShadingRef shading);
+
+/* Whether to fill beyond the start/end of the shading with its end colours. */
+bool OPShadingGetExtendStart(CGShadingRef shading);
+bool OPShadingGetExtendEnd(CGShadingRef shading);

--- a/Source/OpalGraphics/CGShading.m
+++ b/Source/OpalGraphics/CGShading.m
@@ -1,36 +1,55 @@
 /** <title>CGShading</title>
- 
+
  <abstract>C Interface to graphics drawing library</abstract>
- 
+
  Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
 
  Author: Eric Wasylishen
  Date: June 2010
-  
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 2.1 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #import <Foundation/NSObject.h>
-#include "CoreGraphics/CGShading.h"
+#include "CGShading-private.h"
+#include "CoreGraphics/CGColorSpace.h"
 
 @interface CGShading : NSObject
 {
-  
+@public
+  bool radial;
+  CGColorSpaceRef colorspace;
+  CGPoint start;
+  CGPoint end;
+  CGFloat startRadius;
+  CGFloat endRadius;
+  CGFunctionRef function;
+  bool extendStart;
+  bool extendEnd;
 }
 @end
+
 @implementation CGShading
+
+- (void) dealloc
+{
+  CGColorSpaceRelease(colorspace);
+  CGFunctionRelease(function);
+  [super dealloc];
+}
+
 @end
 
 CGShadingRef CGShadingCreateAxial(
@@ -41,7 +60,19 @@ CGShadingRef CGShadingCreateAxial(
   int extendStart,
   int extendEnd)
 {
-  return nil;
+  CGShading *shading = [[CGShading alloc] init];
+
+  shading->radial = false;
+  shading->colorspace = CGColorSpaceRetain(colorspace);
+  shading->start = start;
+  shading->end = end;
+  shading->startRadius = 0;
+  shading->endRadius = 0;
+  shading->function = CGFunctionRetain(function);
+  shading->extendStart = extendStart ? true : false;
+  shading->extendEnd = extendEnd ? true : false;
+
+  return shading;
 }
 
 CGShadingRef CGShadingCreateRadial(
@@ -54,12 +85,24 @@ CGShadingRef CGShadingCreateRadial(
   int extendStart,
   int extendEnd)
 {
-  return nil;
+  CGShading *shading = [[CGShading alloc] init];
+
+  shading->radial = true;
+  shading->colorspace = CGColorSpaceRetain(colorspace);
+  shading->start = start;
+  shading->end = end;
+  shading->startRadius = startRadius;
+  shading->endRadius = endRadius;
+  shading->function = CGFunctionRetain(function);
+  shading->extendStart = extendStart ? true : false;
+  shading->extendEnd = extendEnd ? true : false;
+
+  return shading;
 }
 
 CFTypeID CGShadingGetTypeID()
 {
-  return (CFTypeID)[CGShading class];    
+  return (CFTypeID)[CGShading class];
 }
 
 CGShadingRef CGShadingRetain(CGShadingRef shading)
@@ -68,6 +111,51 @@ CGShadingRef CGShadingRetain(CGShadingRef shading)
 }
 
 void CGShadingRelease(CGShadingRef shading)
-{ 
+{
   [shading release];
+}
+
+bool OPShadingIsRadial(CGShadingRef shading)
+{
+  return shading ? shading->radial : false;
+}
+
+CGColorSpaceRef OPShadingGetColorSpace(CGShadingRef shading)
+{
+  return shading ? shading->colorspace : NULL;
+}
+
+CGFunctionRef OPShadingGetFunction(CGShadingRef shading)
+{
+  return shading ? shading->function : NULL;
+}
+
+CGPoint OPShadingGetStart(CGShadingRef shading)
+{
+  return shading ? shading->start : CGPointZero;
+}
+
+CGPoint OPShadingGetEnd(CGShadingRef shading)
+{
+  return shading ? shading->end : CGPointZero;
+}
+
+CGFloat OPShadingGetStartRadius(CGShadingRef shading)
+{
+  return shading ? shading->startRadius : 0;
+}
+
+CGFloat OPShadingGetEndRadius(CGShadingRef shading)
+{
+  return shading ? shading->endRadius : 0;
+}
+
+bool OPShadingGetExtendStart(CGShadingRef shading)
+{
+  return shading ? shading->extendStart : false;
+}
+
+bool OPShadingGetExtendEnd(CGShadingRef shading)
+{
+  return shading ? shading->extendEnd : false;
 }

--- a/Tests/opal/CGShading/shading.m
+++ b/Tests/opal/CGShading/shading.m
@@ -1,0 +1,118 @@
+/* Draw axial and radial shadings built from a CGFunction into a bitmap and
+   check the result's structure: the ramp is grayscale and monotonic, an
+   un-extended axial shading leaves the area outside its axis untouched, an
+   extended one clamps to its end colours, and a radial shading runs dark at
+   the centre to light at the rim.  Exact bytes are not checked because Apple
+   gamma-curves the interpolation while the cairo backend interpolates
+   linearly; the shape checked here matches Apple CoreGraphics. */
+#include "Testing.h"
+
+#include <CoreGraphics/CGShading.h>
+#include <CoreGraphics/CGFunction.h>
+#include <CoreGraphics/CGContext.h>
+#include <CoreGraphics/CGBitmapContext.h>
+#include <CoreGraphics/CGColorSpace.h>
+#include <stdlib.h>
+
+/* black -> white ramp, opaque */
+static void ramp(void *info, const CGFloat *in, CGFloat *out)
+{
+  CGFloat t = in[0];
+  out[0] = t; out[1] = t; out[2] = t; out[3] = 1;
+}
+
+static CGFunctionRef makeRamp(void)
+{
+  CGFloat domain[] = {0, 1};
+  CGFloat range[] = {0, 1, 0, 1, 0, 1, 0, 1};
+  CGFunctionCallbacks cb = {0, ramp, NULL};
+  return CGFunctionCreate(NULL, 1, domain, 4, range, &cb);
+}
+
+static CGContextRef makeCtx(CGColorSpaceRef dev, unsigned char *buf)
+{
+  return CGBitmapContextCreate(buf, 10, 10, 8, 40, dev,
+    kCGImageAlphaPremultipliedLast);
+}
+
+int main(void)
+{
+  CGColorSpaceRef dev = CGColorSpaceCreateDeviceRGB();
+
+  START_SET("CGShading axial")
+
+  CGFunctionRef fn = makeRamp();
+  PASS(fn != NULL, "a CGFunction is created");
+
+  CGShadingRef sh = CGShadingCreateAxial(dev, CGPointMake(2, 5),
+    CGPointMake(8, 5), fn, 0, 0);
+  PASS(sh != NULL, "an axial shading is created");
+
+  unsigned char *buf = calloc(10 * 10 * 4, 1);
+  CGContextRef c = makeCtx(dev, buf);
+  CGContextDrawShading(c, sh);
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+
+  /* Without extension, the area to either side of the axis is untouched. */
+  PASS(d[(5*10 + 0)*4 + 3] == 0, "an un-extended axial shading leaves the area before its start untouched");
+  PASS(d[(5*10 + 9)*4 + 3] == 0, "an un-extended axial shading leaves the area after its end untouched");
+
+  /* Inside the axis the ramp is opaque, grayscale and gets lighter along +x. */
+  int lo = (5*10 + 3)*4, hi = (5*10 + 6)*4;
+  PASS(d[lo+3] == 255 && d[hi+3] == 255, "the shading fills its axis opaquely");
+  PASS(d[lo] == d[lo+1] && d[lo+1] == d[lo+2]
+       && d[hi] == d[hi+1] && d[hi+1] == d[hi+2],
+       "the ramp stays grayscale");
+  PASS(d[hi] > d[lo], "the ramp gets lighter from start to end");
+
+  CGShadingRelease(sh);
+  free(buf);
+
+  END_SET("CGShading axial")
+
+  START_SET("CGShading axial extended")
+
+  CGFunctionRef fn = makeRamp();
+  CGShadingRef sh = CGShadingCreateAxial(dev, CGPointMake(2, 5),
+    CGPointMake(8, 5), fn, 1, 1);
+  unsigned char *buf = calloc(10 * 10 * 4, 1);
+  CGContextRef c = makeCtx(dev, buf);
+  CGContextDrawShading(c, sh);
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+
+  int before = (5*10 + 0)*4, after = (5*10 + 9)*4;
+  PASS(d[before+3] == 255 && d[after+3] == 255,
+       "an extended axial shading fills beyond its axis");
+  PASS(d[before] < 40, "before the start it clamps to the near-black start colour");
+  PASS(d[after] > 200, "after the end it clamps to the near-white end colour");
+
+  CGShadingRelease(sh);
+  free(buf);
+
+  END_SET("CGShading axial extended")
+
+  START_SET("CGShading radial")
+
+  CGFunctionRef fn = makeRamp();
+  CGShadingRef sh = CGShadingCreateRadial(dev, CGPointMake(5, 5), 0,
+    CGPointMake(5, 5), 5, fn, 1, 1);
+  unsigned char *buf = calloc(10 * 10 * 4, 1);
+  CGContextRef c = makeCtx(dev, buf);
+  CGContextDrawShading(c, sh);
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+
+  int centre = (5*10 + 5)*4, edge = (5*10 + 0)*4;
+  PASS(d[centre+3] == 255 && d[edge+3] == 255, "the radial shading is opaque");
+  PASS(d[centre] == d[centre+1] && d[centre+1] == d[centre+2],
+       "the radial ramp stays grayscale");
+  PASS(d[edge] > d[centre],
+       "the radial ramp runs dark at the centre to light at the rim");
+
+  CGShadingRelease(sh);
+  free(buf);
+
+  END_SET("CGShading radial")
+
+  CGColorSpaceRelease(dev);
+  return 0;
+}


### PR DESCRIPTION
Implements CGShading and CGFunction, which were previously stubs: CGShadingCreateAxial/Radial returned nil, CGFunctionCreate stored none of its arguments, and CGContextDrawShading had only a prototype (no body), so shadings could not be drawn at all.

- **CGFunction** now retains its info pointer, domain, range and callbacks, and can be evaluated (used to sample colours along the shading).
- **CGShading** keeps its colour space, geometry, function and extend flags.
- **CGContextDrawShading** samples the function along the axis, builds a Cairo linear (axial) or radial gradient from the samples, honours the extend flags — padding to the end colours when both ends extend, and leaving the surrounding area untouched otherwise — and paints it. Only DeviceRGB is supported for now, matching the existing gradient drawing.

Adds axial and radial render tests (`Tests/opal/CGShading`) that check the ramp is grayscale and monotonic, that an un-extended axial shading leaves the area outside its axis untouched, that an extended one clamps to its end colours, and that a radial shading runs dark at the centre to light at the rim. Exact bytes are not asserted because Apple gamma-curves the interpolation while the Cairo backend interpolates linearly; the structure checked matches Apple CoreGraphics.