### PR TITLE
Fix: report the font ascent and descent the way CoreGraphics does

### DIFF
--- a/Source/OpalGraphics/cairo/CairoFontX11.m
+++ b/Source/OpalGraphics/cairo/CairoFontX11.m
@@ -283,7 +283,7 @@ static FcPattern *opal_FcPatternCacheLookup(const char *name)
 - (int) ascent;
 {
   FT_Face ft_face = cairo_ft_scaled_font_lock_face(self->cairofont);
-  int result = ft_face->bbox.yMax;
+  int result = ft_face->ascender;
   cairo_ft_scaled_font_unlock_face(self->cairofont);
   return result;
 }
@@ -305,7 +305,7 @@ static FcPattern *opal_FcPatternCacheLookup(const char *name)
 - (int) descent;
 {
   FT_Face ft_face = cairo_ft_scaled_font_lock_face(self->cairofont);
-  int result = -ft_face->descender;
+  int result = ft_face->descender;
 
   cairo_ft_scaled_font_unlock_face(self->cairofont);
   return result;


### PR DESCRIPTION
`CGFontGetAscent` returned the top of the font's bounding box rather than the typographic ascender, so it was larger than the ascent CoreGraphics reports — and often larger than the em — because the bounding box includes the tallest accents and overshoots. `CGFontGetDescent` negated FreeType's descender and so returned a positive number, whereas CoreGraphics reports the descent as a negative distance below the baseline.

The ascent now returns FreeType's `ascender` and the descent its (already negative) `descender`.

For example, for DejaVu Sans (units-per-em 2048): ascent 2524 -> 1901, descent +483 -> -483, matching the CoreGraphics conventions (ascent below the bounding-box top, descent negative). Verified on macOS: Helvetica ascent 1577 / descent -471, Times New Roman 1825 / -443, Courier 1544 / -504 — all with ascent well below the bounding-box top.

A regression test is added in #38; the two convention checks are marked hopeful there and pass once this is merged.