### PR TITLE
Fix: call the releaseData callback of a data provider

### DIFF
--- a/Source/OpalGraphics/CGDataProvider.m
+++ b/Source/OpalGraphics/CGDataProvider.m
@@ -349,6 +349,7 @@ size_t OPDataProviderGetBytesAtPositionCallback(
 typedef struct DataInfo {
   size_t size;
   const void *data;
+  void *info;
   CGDataProviderReleaseDataCallback releaseData;
 } DataInfo;
 
@@ -375,7 +376,12 @@ static size_t opal_DataGetBytesAtPosition(
 
 static void opal_DataReleaseInfo(void *info)
 {
-  free((DataInfo*)info);
+  DataInfo *di = (DataInfo*)info;
+  if (di->releaseData)
+  {
+    di->releaseData(di->info, di->data, di->size);
+  }
+  free(di);
 }
 
 static const CGDataProviderDirectCallbacks opal_DataCallbacks = {
@@ -542,8 +548,9 @@ CGDataProviderRef CGDataProviderCreateWithData(
   DataInfo *i = malloc(sizeof(DataInfo));
   i->size = size;
   i->data = data;
+  i->info = info;
   i->releaseData = releaseData;
-  
+
   return CGDataProviderCreateDirect(i, size, &opal_DataCallbacks);
 }
 


### PR DESCRIPTION
A data provider created with `CGDataProviderCreateWithData` is supposed to call the caller's `releaseData` callback when it is freed, so the caller can release the buffer it supplied. Opal stored the callback but never called it - and did not even keep the caller's `info` pointer - so the supplied buffer was leaked and the callback's side effects never ran.

The bookkeeping struct now also keeps the `info` pointer, and when the provider is released it calls `releaseData(info, data, size)` with the original arguments before freeing the struct.

Verified against Apple CoreGraphics: `releaseData` fires exactly once on release, with the original info pointer, data pointer and size. A regression test is added in #44 (the two checks are marked hopeful there and pass once this is merged).