### PR TITLE
Fix: compute bytesPerRow when a bitmap context is given zero

### DIFF
--- a/Source/OpalGraphics/CGBitmapContext.m
+++ b/Source/OpalGraphics/CGBitmapContext.m
@@ -268,7 +268,17 @@ CGContextRef CGBitmapContextCreateWithData(
             "<callback>, <releaseinfo>",
             data, width, height, bitsPerComponent, bytesPerRow)
   cairo_format_t format = CAIRO_FORMAT_INVALID;
-  cairo_surface_t *surf;  
+  cairo_surface_t *surf;
+
+  // A zero bytesPerRow means "compute it from the width and pixel format".
+  if (bytesPerRow == 0)
+  {
+      size_t colorComps = CGColorSpaceGetNumberOfComponents(cs);
+      size_t alphaComps =
+        ((info & kCGBitmapAlphaInfoMask) != kCGImageAlphaNone) ? 1 : 0;
+      size_t bitsPerPixel = bitsPerComponent * (colorComps + alphaComps);
+      bytesPerRow = (width * bitsPerPixel + 7) / 8;
+  }
 
   // Create the user requested buffer
   if (data == NULL)


### PR DESCRIPTION
`CGBitmapContextCreate` accepts a `bytesPerRow` of 0 to mean "work it out from the width and pixel format", but Opal stored the 0 verbatim. It then allocated a zero-length backing buffer (`calloc(height * 0, 1)`), created the cairo surface with a zero stride, and reported 0 from `CGBitmapContextGetBytesPerRow` - so a context created this way was unusable.

When `bytesPerRow` is 0, it is now computed from the width, bits per component and the number of colour (plus alpha) components before the buffer and surface are built.

Verified against Apple CoreGraphics: an explicit bytes-per-row is echoed, and a 0 produces a row of at least `width * bytesPerPixel` (Apple additionally aligns it up; the alignment is not part of the contract). After the fix a 10x8 RGBA context with bytesPerRow 0 reports 40 and draws correctly. A regression test is in #46 (marked hopeful there; passes once this is merged).