### PR TITLE
Feature: implement CGPattern fills (colored and uncolored)

### DIFF
--- a/Source/OpalGraphics/CGColorSpace.m
+++ b/Source/OpalGraphics/CGColorSpace.m
@@ -30,6 +30,7 @@
 
 #import "CGColorSpace-private.h"
 #import "OPColorSpaceIndexed.h"
+#import "OPColorSpacePattern.h"
 
 const CFStringRef kCGColorSpaceGenericGray = @"kCGColorSpaceGenericGray";
 const CFStringRef kCGColorSpaceGenericRGB = @"kCGColorSpaceGenericRGB";
@@ -164,8 +165,7 @@ CGColorSpaceRef CGColorSpaceCreateLab(
 
 CGColorSpaceRef CGColorSpaceCreatePattern(CGColorSpaceRef baseSpace)
 {
-  // FIXME: implement
-  return nil;
+  return [[OPColorSpacePattern alloc] initWithBaseSpace: baseSpace];
 }
 
 CGColorSpaceRef CGColorSpaceCreateWithICCProfile(CFDataRef data)

--- a/Source/OpalGraphics/CGContext-private.h
+++ b/Source/OpalGraphics/CGContext-private.h
@@ -47,6 +47,7 @@ struct ct_additions
   CGFloat font_size;
   CGFloat char_spacing;
   CGTextDrawingMode text_mode;
+  CGSize pattern_phase;
 };
 
 @interface CGContext : NSObject

--- a/Source/OpalGraphics/CGContext-private.h
+++ b/Source/OpalGraphics/CGContext-private.h
@@ -48,6 +48,8 @@ struct ct_additions
   CGFloat char_spacing;
   CGTextDrawingMode text_mode;
   CGSize pattern_phase;
+  CGColorSpaceRef fill_cs;
+  CGColorSpaceRef stroke_cs;
 };
 
 @interface CGContext : NSObject

--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -30,9 +30,14 @@
 
 #import "CGContext-private.h"
 #import "CGGradient-private.h"
+#import "CGPattern-private.h"
 #import "CGColor-private.h"
 #import "cairo/CairoFont.h"
 #import "OPLogging.h"
+
+#include <math.h>
+
+extern CGContextRef opal_new_CGContext(cairo_surface_t *target, CGSize device_size);
 
 /* The default (opaque black) color in a Cairo context,
  * used if no other color is set on the context yet */
@@ -453,7 +458,50 @@ void CGContextSetInterpolationQuality(
 void CGContextSetPatternPhase (CGContextRef ctx, CGSize phase)
 {
   OPLOGCALL("ctx /*%p*/, CGSizeMake(%g, %g)", ctx, phase.width, phase.height)
+  ctx->add->pattern_phase = phase;
   OPRESTORELOGGING()
+}
+
+/* Build a repeating Cairo source pattern from a CGPattern by drawing one cell
+   into an offscreen surface and tiling it.  Only colored patterns are handled;
+   an uncolored pattern would need its cell tinted with the caller's colour
+   components, which requires the pattern colour space's base space. */
+static cairo_pattern_t *opal_CreatePatternSource(CGContextRef ctx,
+  CGPatternRef pattern)
+{
+  const CGRect bounds = OPPatternGetBounds(pattern);
+  CGFloat xStep = OPPatternGetXStep(pattern);
+  CGFloat yStep = OPPatternGetYStep(pattern);
+  if (xStep <= 0) xStep = bounds.size.width;
+  if (yStep <= 0) yStep = bounds.size.height;
+
+  int cw = (int)ceil(xStep);
+  int ch = (int)ceil(yStep);
+  if (cw < 1) cw = 1;
+  if (ch < 1) ch = 1;
+
+  /* Draw one cell into an offscreen surface using a temporary context that
+     shares Opal's flipped coordinate convention. */
+  cairo_surface_t *cell = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, cw, ch);
+  CGContextRef cellCtx = opal_new_CGContext(cell, CGSizeMake(cw, ch));
+  CGContextTranslateCTM(cellCtx, -bounds.origin.x, -bounds.origin.y);
+  OPPatternDrawInContext(pattern, cellCtx);
+  CGContextFlush(cellCtx);
+
+  cairo_pattern_t *pat = cairo_pattern_create_for_surface(cell);
+  cairo_pattern_set_extend(pat, CAIRO_EXTEND_REPEAT);
+
+  /* The cell surface is stored top-down while the drawing context is flipped;
+     flip the pattern back and apply the phase so tiles line up with the fill
+     origin. */
+  const CGSize phase = ctx->add->pattern_phase;
+  cairo_matrix_t m;
+  cairo_matrix_init(&m, 1, 0, 0, -1, -phase.width, ch + phase.height);
+  cairo_pattern_set_matrix(pat, &m);
+
+  CGContextRelease(cellCtx);
+  cairo_surface_destroy(cell);
+  return pat;
 }
 
 void CGContextSetFillPattern(
@@ -462,6 +510,14 @@ void CGContextSetFillPattern(
   const CGFloat components[])
 {
   OPLOGCALL("ctx /*%p*/, <pattern>, <components>", ctx)
+  if (pattern != NULL)
+    {
+      if (ctx->add->fill_cp)
+        {
+          cairo_pattern_destroy(ctx->add->fill_cp);
+        }
+      ctx->add->fill_cp = opal_CreatePatternSource(ctx, pattern);
+    }
   OPRESTORELOGGING()
 }
 
@@ -471,6 +527,14 @@ void CGContextSetStrokePattern(
   const CGFloat components[])
 {
   OPLOGCALL("ctx /*%p*/, <pattern>, <components>", ctx)
+  if (pattern != NULL)
+    {
+      if (ctx->add->stroke_cp)
+        {
+          cairo_pattern_destroy(ctx->add->stroke_cp);
+        }
+      ctx->add->stroke_cp = opal_CreatePatternSource(ctx, pattern);
+    }
   OPRESTORELOGGING()
 }
 

--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -33,6 +33,7 @@
 #import "CGShading-private.h"
 #import "CGFunction-private.h"
 #import "CGColor-private.h"
+#import "CGPattern-private.h"
 #import "cairo/CairoFont.h"
 #import "OPLogging.h"
 

--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -112,6 +112,8 @@ static void end_shadow(CGContextRef ctx, CGRect bounds);
     CGColorRelease(ctadd->shadow_color);
     cairo_pattern_destroy(ctadd->shadow_cp);
     CGFontRelease(ctadd->font);
+    CGColorSpaceRelease(ctadd->fill_cs);
+    CGColorSpaceRelease(ctadd->stroke_cs);
     next = ctadd->next;
     free(ctadd);
     ctadd = next;
@@ -338,6 +340,8 @@ void CGContextSaveGState(CGContextRef ctx)
   cairo_pattern_reference(ctadd->fill_cp);
   CGColorRetain(ctadd->stroke_color);
   cairo_pattern_reference(ctadd->stroke_cp);
+  CGColorSpaceRetain(ctadd->fill_cs);
+  CGColorSpaceRetain(ctadd->stroke_cs);
   ctadd->next = ctx->add;
   ctx->add = ctadd;
   OPRESTORELOGGING()
@@ -362,6 +366,8 @@ void CGContextRestoreGState(CGContextRef ctx)
   cairo_pattern_destroy(ctx->add->fill_cp);
   CGColorRelease(ctx->add->stroke_color);
   cairo_pattern_destroy(ctx->add->stroke_cp);
+  CGColorSpaceRelease(ctx->add->fill_cs);
+  CGColorSpaceRelease(ctx->add->stroke_cs);
   ctadd = ctx->add->next;
   free(ctx->add);
   ctx->add = ctadd;
@@ -463,11 +469,11 @@ void CGContextSetPatternPhase (CGContextRef ctx, CGSize phase)
 }
 
 /* Build a repeating Cairo source pattern from a CGPattern by drawing one cell
-   into an offscreen surface and tiling it.  Only colored patterns are handled;
-   an uncolored pattern would need its cell tinted with the caller's colour
-   components, which requires the pattern colour space's base space. */
+   into an offscreen surface and tiling it.  For an uncolored pattern cellColor
+   is the colour (in the pattern's base space) that the cell is drawn with; for
+   a colored pattern it is NULL and the cell draws its own colours. */
 static cairo_pattern_t *opal_CreatePatternSource(CGContextRef ctx,
-  CGPatternRef pattern)
+  CGPatternRef pattern, CGColorRef cellColor)
 {
   const CGRect bounds = OPPatternGetBounds(pattern);
   CGFloat xStep = OPPatternGetXStep(pattern);
@@ -485,6 +491,11 @@ static cairo_pattern_t *opal_CreatePatternSource(CGContextRef ctx,
   cairo_surface_t *cell = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, cw, ch);
   CGContextRef cellCtx = opal_new_CGContext(cell, CGSizeMake(cw, ch));
   CGContextTranslateCTM(cellCtx, -bounds.origin.x, -bounds.origin.y);
+  if (cellColor != NULL)
+    {
+      CGContextSetFillColorWithColor(cellCtx, cellColor);
+      CGContextSetStrokeColorWithColor(cellCtx, cellColor);
+    }
   OPPatternDrawInContext(pattern, cellCtx);
   CGContextFlush(cellCtx);
 
@@ -504,6 +515,30 @@ static cairo_pattern_t *opal_CreatePatternSource(CGContextRef ctx,
   return pat;
 }
 
+/* For an uncolored pattern, build the colour its cell should be drawn with
+   from the caller's components in the pattern colour space's base space.
+   Returns NULL (caller draws its own colours) for a colored pattern or when no
+   pattern colour space with a base is in effect.  The returned colour, if any,
+   must be released by the caller. */
+static CGColorRef opal_PatternCellColor(CGColorSpaceRef pcs,
+  CGPatternRef pattern, const CGFloat components[])
+{
+  if (OPPatternIsColored(pattern) || components == NULL || pcs == NULL)
+    {
+      return NULL;
+    }
+  if (CGColorSpaceGetModel(pcs) != kCGColorSpaceModelPattern)
+    {
+      return NULL;
+    }
+  CGColorSpaceRef base = CGColorSpaceGetBaseColorSpace(pcs);
+  if (base == NULL)
+    {
+      return NULL;
+    }
+  return CGColorCreate(base, components);
+}
+
 void CGContextSetFillPattern(
   CGContextRef ctx,
   CGPatternRef pattern,
@@ -512,11 +547,14 @@ void CGContextSetFillPattern(
   OPLOGCALL("ctx /*%p*/, <pattern>, <components>", ctx)
   if (pattern != NULL)
     {
+      CGColorRef cellColor =
+        opal_PatternCellColor(ctx->add->fill_cs, pattern, components);
       if (ctx->add->fill_cp)
         {
           cairo_pattern_destroy(ctx->add->fill_cp);
         }
-      ctx->add->fill_cp = opal_CreatePatternSource(ctx, pattern);
+      ctx->add->fill_cp = opal_CreatePatternSource(ctx, pattern, cellColor);
+      CGColorRelease(cellColor);
     }
   OPRESTORELOGGING()
 }
@@ -529,11 +567,14 @@ void CGContextSetStrokePattern(
   OPLOGCALL("ctx /*%p*/, <pattern>, <components>", ctx)
   if (pattern != NULL)
     {
+      CGColorRef cellColor =
+        opal_PatternCellColor(ctx->add->stroke_cs, pattern, components);
       if (ctx->add->stroke_cp)
         {
           cairo_pattern_destroy(ctx->add->stroke_cp);
         }
-      ctx->add->stroke_cp = opal_CreatePatternSource(ctx, pattern);
+      ctx->add->stroke_cp = opal_CreatePatternSource(ctx, pattern, cellColor);
+      CGColorRelease(cellColor);
     }
   OPRESTORELOGGING()
 }
@@ -1279,6 +1320,22 @@ void CGContextSetFillColorSpace(CGContextRef ctx, CGColorSpaceRef colorspace)
   CGColorRef color;
   size_t nc;
 
+  if (ctx && ctx->add)
+    {
+      CGColorSpaceRetain(colorspace);
+      CGColorSpaceRelease(ctx->add->fill_cs);
+      ctx->add->fill_cs = colorspace;
+    }
+
+  /* A pattern colour space carries no colour of its own; the fill colour is
+     supplied later by CGContextSetFillPattern. */
+  if (colorspace != NULL
+      && CGColorSpaceGetModel(colorspace) == kCGColorSpaceModelPattern)
+    {
+      OPRESTORELOGGING()
+      return;
+    }
+
   nc = CGColorSpaceGetNumberOfComponents(colorspace);
   components = calloc(nc+1, sizeof(CGFloat));
   if (components) {
@@ -1300,6 +1357,22 @@ void CGContextSetStrokeColorSpace(CGContextRef ctx, CGColorSpaceRef colorspace)
   CGFloat *components;
   CGColorRef color;
   size_t nc;
+
+  if (ctx && ctx->add)
+    {
+      CGColorSpaceRetain(colorspace);
+      CGColorSpaceRelease(ctx->add->stroke_cs);
+      ctx->add->stroke_cs = colorspace;
+    }
+
+  /* A pattern colour space carries no colour of its own; the stroke colour is
+     supplied later by CGContextSetStrokePattern. */
+  if (colorspace != NULL
+      && CGColorSpaceGetModel(colorspace) == kCGColorSpaceModelPattern)
+    {
+      OPRESTORELOGGING()
+      return;
+    }
 
   nc = CGColorSpaceGetNumberOfComponents(colorspace);
   components = calloc(nc+1, sizeof(CGFloat));

--- a/Source/OpalGraphics/CGPattern-private.h
+++ b/Source/OpalGraphics/CGPattern-private.h
@@ -2,10 +2,10 @@
 
  <abstract>C Interface to graphics drawing library</abstract>
 
- Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+ Copyright <copy>(C) 2026 Free Software Foundation, Inc.</copy>
 
- Author: Eric Wasylishen
- Date: June 2010
+ Author: Todd White <todd.white@thalion.global>
+ Date: July 2026
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/Source/OpalGraphics/CGPattern-private.h
+++ b/Source/OpalGraphics/CGPattern-private.h
@@ -1,0 +1,34 @@
+/** <title>CGPattern-private</title>
+
+ <abstract>C Interface to graphics drawing library</abstract>
+
+ Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+
+ Author: Eric Wasylishen
+ Date: June 2010
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "CoreGraphics/CGPattern.h"
+
+CGRect OPPatternGetBounds(CGPatternRef pattern);
+CGAffineTransform OPPatternGetMatrix(CGPatternRef pattern);
+CGFloat OPPatternGetXStep(CGPatternRef pattern);
+CGFloat OPPatternGetYStep(CGPatternRef pattern);
+bool OPPatternIsColored(CGPatternRef pattern);
+
+/* Run the pattern's draw callback, drawing one cell into ctx. */
+void OPPatternDrawInContext(CGPatternRef pattern, CGContextRef ctx);

--- a/Source/OpalGraphics/CGPattern.m
+++ b/Source/OpalGraphics/CGPattern.m
@@ -1,36 +1,55 @@
 /** <title>CGPattern</title>
- 
+
  <abstract>C Interface to graphics drawing library</abstract>
- 
+
  Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
 
  Author: Eric Wasylishen
  Date: June 2010
- 
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 2.1 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #import <Foundation/NSObject.h>
-#include "CoreGraphics/CGPattern.h"
+#include "CGPattern-private.h"
 
 @interface CGPattern : NSObject
 {
+@public
   void *info;
+  CGRect bounds;
+  CGAffineTransform matrix;
+  CGFloat xStep;
+  CGFloat yStep;
+  CGPatternTiling tiling;
+  bool isColored;
+  CGPatternCallbacks callbacks;
 }
 @end
+
 @implementation CGPattern
+
+- (void) dealloc
+{
+  if (callbacks.releaseInfo)
+    {
+      callbacks.releaseInfo(info);
+    }
+  [super dealloc];
+}
+
 @end
 
 
@@ -44,9 +63,23 @@ CGPatternRef CGPatternCreate(
   int isColored,
   const CGPatternCallbacks *callbacks)
 {
-  CGPatternRef pattern = nil;
-  
-  // FIXME
+  CGPattern *pattern = [[CGPattern alloc] init];
+
+  pattern->info = info;
+  pattern->bounds = bounds;
+  pattern->matrix = matrix;
+  pattern->xStep = xStep;
+  pattern->yStep = yStep;
+  pattern->tiling = tiling;
+  pattern->isColored = isColored ? true : false;
+  if (callbacks)
+    {
+      pattern->callbacks = *callbacks;
+    }
+  else
+    {
+      memset(&pattern->callbacks, 0, sizeof(CGPatternCallbacks));
+    }
 
   return pattern;
 }
@@ -66,4 +99,35 @@ void CGPatternRelease(CGPatternRef pattern)
   [pattern release];
 }
 
+CGRect OPPatternGetBounds(CGPatternRef pattern)
+{
+  return pattern ? pattern->bounds : CGRectZero;
+}
 
+CGAffineTransform OPPatternGetMatrix(CGPatternRef pattern)
+{
+  return pattern ? pattern->matrix : CGAffineTransformIdentity;
+}
+
+CGFloat OPPatternGetXStep(CGPatternRef pattern)
+{
+  return pattern ? pattern->xStep : 0;
+}
+
+CGFloat OPPatternGetYStep(CGPatternRef pattern)
+{
+  return pattern ? pattern->yStep : 0;
+}
+
+bool OPPatternIsColored(CGPatternRef pattern)
+{
+  return pattern ? pattern->isColored : false;
+}
+
+void OPPatternDrawInContext(CGPatternRef pattern, CGContextRef ctx)
+{
+  if (pattern && pattern->callbacks.drawPattern)
+    {
+      pattern->callbacks.drawPattern(pattern->info, ctx);
+    }
+}

--- a/Source/OpalGraphics/OPColorSpacePattern.h
+++ b/Source/OpalGraphics/OPColorSpacePattern.h
@@ -2,10 +2,10 @@
 
    <abstract>C Interface to graphics drawing library</abstract>
 
-   Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+   Copyright <copy>(C) 2026 Free Software Foundation, Inc.</copy>
 
-   Author: Eric Wasylishen <ewasylishen@gmail.com>
-   Date: July, 2010
+   Author: Todd White <todd.white@thalion.global>
+   Date: July 2026
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public

--- a/Source/OpalGraphics/OPColorSpacePattern.h
+++ b/Source/OpalGraphics/OPColorSpacePattern.h
@@ -1,0 +1,41 @@
+/** <title>OPColorSpacePattern</title>
+
+   <abstract>C Interface to graphics drawing library</abstract>
+
+   Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+
+   Author: Eric Wasylishen <ewasylishen@gmail.com>
+   Date: July, 2010
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+   */
+
+#include "CoreGraphics/CGColorSpace.h"
+#import "CGColorSpace-private.h"
+
+/**
+ * A pattern colour space.  A colored pattern has no base space; an uncolored
+ * pattern carries a base space whose components colour the pattern cell.
+ */
+@interface OPColorSpacePattern : NSObject
+{
+@public
+  CGColorSpaceRef base;
+}
+
+- (id) initWithBaseSpace: (CGColorSpaceRef)aBaseSpace;
+- (CGColorSpaceRef) baseColorSpace;
+
+@end

--- a/Source/OpalGraphics/OPColorSpacePattern.m
+++ b/Source/OpalGraphics/OPColorSpacePattern.m
@@ -2,10 +2,10 @@
 
    <abstract>C Interface to graphics drawing library</abstract>
 
-   Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+   Copyright <copy>(C) 2026 Free Software Foundation, Inc.</copy>
 
-   Author: Eric Wasylishen <ewasylishen@gmail.com>
-   Date: July, 2010
+   Author: Todd White <todd.white@thalion.global>
+   Date: July 2026
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public

--- a/Source/OpalGraphics/OPColorSpacePattern.m
+++ b/Source/OpalGraphics/OPColorSpacePattern.m
@@ -1,0 +1,89 @@
+/** <title>OPColorSpacePattern</title>
+
+   <abstract>C Interface to graphics drawing library</abstract>
+
+   Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+
+   Author: Eric Wasylishen <ewasylishen@gmail.com>
+   Date: July, 2010
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+   */
+
+#import <Foundation/NSObject.h>
+#include "OPColorSpacePattern.h"
+
+@implementation OPColorSpacePattern
+
+- (id) initWithBaseSpace: (CGColorSpaceRef)aBaseSpace
+{
+  self = [super init];
+  if (self)
+    {
+      base = CGColorSpaceRetain(aBaseSpace);
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  CGColorSpaceRelease(base);
+  [super dealloc];
+}
+
+- (CGColorSpaceRef) baseColorSpace
+{
+  return base;
+}
+
+- (CGColorSpaceModel) model
+{
+  return kCGColorSpaceModelPattern;
+}
+
+- (size_t) numberOfComponents
+{
+  return base ? CGColorSpaceGetNumberOfComponents(base) : 0;
+}
+
+- (NSData *) ICCProfile
+{
+  return nil;
+}
+
+- (NSString *) name
+{
+  return nil;
+}
+
+- (BOOL) isEqual: (id)other
+{
+  if (self == other)
+    {
+      return YES;
+    }
+  if (![other isKindOfClass: [OPColorSpacePattern class]])
+    {
+      return NO;
+    }
+  CGColorSpaceRef otherBase = ((OPColorSpacePattern *)other)->base;
+  if (base == otherBase)
+    {
+      return YES;
+    }
+  return base != NULL && otherBase != NULL && [(id)base isEqual: (id)otherBase];
+}
+
+@end

--- a/Tests/opal/CGPattern/pattern.m
+++ b/Tests/opal/CGPattern/pattern.m
@@ -1,0 +1,93 @@
+/* A colored CGPattern is drawn by tiling its cell over a fill.  A 4x4 cell that
+   paints one half green tiles with a period of 4 pixels; filling a 12x8 rect
+   repeats the green/clear stripes.  Green stroke/fill on a transparent
+   device-RGB bitmap; a pixel is "painted" when its alpha is non-zero.  The
+   tiling period, origin and orientation match Apple CoreGraphics (exact
+   antialiased edges are not compared - the cell edges are whole pixels here). */
+#include "Testing.h"
+
+#include <CoreGraphics/CGPattern.h>
+#include <CoreGraphics/CGContext.h>
+#include <CoreGraphics/CGBitmapContext.h>
+#include <CoreGraphics/CGColorSpace.h>
+#include <stdlib.h>
+
+#define W 12
+#define H 8
+
+/* Cell painting its left half (x 0..2) green. */
+static void drawLeft(void *info, CGContextRef c)
+{
+  CGContextSetRGBFillColor(c, 0, 1, 0, 1);
+  CGContextFillRect(c, CGRectMake(0, 0, 2, 4));
+}
+
+/* Cell painting its bottom half (y 0..2) green. */
+static void drawBottom(void *info, CGContextRef c)
+{
+  CGContextSetRGBFillColor(c, 0, 1, 0, 1);
+  CGContextFillRect(c, CGRectMake(0, 0, 4, 2));
+}
+
+static int A(unsigned char *d, int x, int y) { return d[(y*W + x)*4 + 3]; }
+
+static CGContextRef fillWithPattern(unsigned char *buf, CGColorSpaceRef dev,
+  CGPatternDrawPatternCallback draw)
+{
+  CGContextRef c = CGBitmapContextCreate(buf, W, H, 8, W*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGPatternCallbacks cb = {0, draw, NULL};
+  CGPatternRef pat = CGPatternCreate(NULL, CGRectMake(0, 0, 4, 4),
+    CGAffineTransformIdentity, 4, 4, kCGPatternTilingNoDistortion, 1, &cb);
+  CGContextSetFillPattern(c, pat, NULL);
+  CGContextFillRect(c, CGRectMake(0, 0, W, H));
+  CGPatternRelease(pat);
+  return c;
+}
+
+int main(void)
+{
+  CGColorSpaceRef dev = CGColorSpaceCreateDeviceRGB();
+
+  START_SET("CGPattern creation")
+
+  CGPatternCallbacks cb = {0, drawLeft, NULL};
+  CGPatternRef pat = CGPatternCreate(NULL, CGRectMake(0, 0, 4, 4),
+    CGAffineTransformIdentity, 4, 4, kCGPatternTilingNoDistortion, 1, &cb);
+  PASS(pat != NULL, "a pattern is created");
+  CGPatternRelease(pat);
+
+  END_SET("CGPattern creation")
+
+  START_SET("CGPattern horizontal tiling")
+
+  unsigned char *buf = calloc(W*H*4, 1);
+  CGContextRef c = fillWithPattern(buf, dev, drawLeft);
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+  /* Left half of each 4px cell is green, right half clear, repeating. */
+  PASS(A(d,0,4) > 0 && A(d,1,4) > 0, "the cell's painted half is drawn");
+  PASS(A(d,2,4) == 0 && A(d,3,4) == 0, "the cell's clear half is left clear");
+  PASS(A(d,4,4) > 0 && A(d,5,4) > 0, "the pattern repeats a cell later");
+  PASS(A(d,6,4) == 0 && A(d,7,4) == 0, "the clear half repeats too");
+  PASS(A(d,8,4) > 0 && A(d,9,4) > 0, "and repeats again across the fill");
+  CGContextRelease(c); free(buf);
+
+  END_SET("CGPattern horizontal tiling")
+
+  START_SET("CGPattern vertical tiling")
+
+  unsigned char *buf = calloc(W*H*4, 1);
+  CGContextRef c = fillWithPattern(buf, dev, drawBottom);
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+  /* The pattern tiles vertically with a period of 4, matching Apple's cell
+     placement (the cell's painted band lands at y 2..4 and 6..8). */
+  PASS(A(d,1,2) > 0 && A(d,1,3) > 0, "a painted band of the cell is drawn");
+  PASS(A(d,1,0) == 0 && A(d,1,1) == 0, "the cell's clear band is left clear");
+  PASS(A(d,1,6) > 0 && A(d,1,7) > 0, "the band repeats a cell later vertically");
+  CGContextRelease(c); free(buf);
+
+  END_SET("CGPattern vertical tiling")
+
+  CGColorSpaceRelease(dev);
+  return 0;
+}

--- a/Tests/opal/CGPattern/pattern.m
+++ b/Tests/opal/CGPattern/pattern.m
@@ -1,8 +1,10 @@
-/* A colored CGPattern is drawn by tiling its cell over a fill.  A 4x4 cell that
-   paints one half green tiles with a period of 4 pixels; filling a 12x8 rect
-   repeats the green/clear stripes.  Green stroke/fill on a transparent
-   device-RGB bitmap; a pixel is "painted" when its alpha is non-zero.  The
-   tiling period, origin and orientation match Apple CoreGraphics (exact
+/* A CGPattern is drawn by tiling its cell over a fill.  A 4x4 cell that paints
+   one half tiles with a period of 4 pixels; filling a 12x8 rect repeats the
+   painted/clear stripes.  Colored patterns paint their own colours; uncolored
+   patterns are tinted with the caller's components (via the pattern colour
+   space's base space).  Transparent device-RGB bitmap; a pixel is "painted"
+   when its alpha is non-zero.  The tiling period, origin and orientation, and
+   the pattern colour space properties, match Apple CoreGraphics (exact
    antialiased edges are not compared - the cell edges are whole pixels here). */
 #include "Testing.h"
 
@@ -10,6 +12,7 @@
 #include <CoreGraphics/CGContext.h>
 #include <CoreGraphics/CGBitmapContext.h>
 #include <CoreGraphics/CGColorSpace.h>
+#include <CoreGraphics/CGColor.h>
 #include <stdlib.h>
 
 #define W 12
@@ -29,7 +32,14 @@ static void drawBottom(void *info, CGContextRef c)
   CGContextFillRect(c, CGRectMake(0, 0, 4, 2));
 }
 
+/* Cell painting its left half with the current (caller-supplied) colour. */
+static void drawLeftUncolored(void *info, CGContextRef c)
+{
+  CGContextFillRect(c, CGRectMake(0, 0, 2, 4));
+}
+
 static int A(unsigned char *d, int x, int y) { return d[(y*W + x)*4 + 3]; }
+static int chan(unsigned char *d, int x, int y, int i) { return d[(y*W + x)*4 + i]; }
 
 static CGContextRef fillWithPattern(unsigned char *buf, CGColorSpaceRef dev,
   CGPatternDrawPatternCallback draw)
@@ -87,6 +97,57 @@ int main(void)
   CGContextRelease(c); free(buf);
 
   END_SET("CGPattern vertical tiling")
+
+  START_SET("CGPattern colour space")
+
+  CGColorSpaceRef colored = CGColorSpaceCreatePattern(NULL);
+  PASS(colored != NULL, "a colored pattern colour space is created");
+  PASS(CGColorSpaceGetModel(colored) == kCGColorSpaceModelPattern,
+       "its model is the pattern model");
+  PASS(CGColorSpaceGetNumberOfComponents(colored) == 0,
+       "a colored pattern colour space has no components");
+  PASS(CGColorSpaceGetBaseColorSpace(colored) == NULL,
+       "a colored pattern colour space has no base");
+  CGColorSpaceRelease(colored);
+
+  CGColorSpaceRef uncolored = CGColorSpaceCreatePattern(dev);
+  PASS(CGColorSpaceGetModel(uncolored) == kCGColorSpaceModelPattern,
+       "an uncolored pattern colour space's model is the pattern model");
+  PASS(CGColorSpaceGetNumberOfComponents(uncolored) == 3,
+       "its component count comes from its base");
+  PASS(CGColorSpaceGetModel(CGColorSpaceGetBaseColorSpace(uncolored))
+         == kCGColorSpaceModelRGB,
+       "its base colour space is reported");
+  CGColorSpaceRelease(uncolored);
+
+  END_SET("CGPattern colour space")
+
+  START_SET("CGPattern uncolored")
+
+  unsigned char *buf = calloc(W*H*4, 1);
+  CGContextRef c = CGBitmapContextCreate(buf, W, H, 8, W*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGPatternCallbacks cb = {0, drawLeftUncolored, NULL};
+  CGPatternRef pat = CGPatternCreate(NULL, CGRectMake(0, 0, 4, 4),
+    CGAffineTransformIdentity, 4, 4, kCGPatternTilingNoDistortion, 0, &cb);
+  CGColorSpaceRef pcs = CGColorSpaceCreatePattern(dev);
+  CGContextSetFillColorSpace(c, pcs);
+  CGFloat blue[] = {0, 0, 1, 1};
+  CGContextSetFillPattern(c, pat, blue);
+  CGContextFillRect(c, CGRectMake(0, 0, W, H));
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+  /* The cell is tinted with the caller's blue and tiled. */
+  PASS(A(d,1,4) > 0 && chan(d,1,4,2) > 200
+         && chan(d,1,4,0) < 60 && chan(d,1,4,1) < 60,
+       "an uncolored pattern is tinted with the caller's colour");
+  PASS(A(d,3,4) == 0, "the cell's clear half is left clear");
+  PASS(A(d,5,4) > 0 && chan(d,5,4,2) > 200,
+       "the tinted pattern repeats across the fill");
+  CGPatternRelease(pat);
+  CGColorSpaceRelease(pcs);
+  CGContextRelease(c); free(buf);
+
+  END_SET("CGPattern uncolored")
 
   CGColorSpaceRelease(dev);
   return 0;


### PR DESCRIPTION
Implements CGPattern fills, which were previously stubs: `CGPatternCreate` returned nil and the pattern setters were empty, so patterns could not be drawn. `CGColorSpaceCreatePattern` also returned nil.

- **CGPattern** keeps its info, bounds, matrix, x/y step, tiling and callbacks.
- **CGContextSetFillPattern** / **CGContextSetStrokePattern** draw one pattern cell into an offscreen surface with the pattern's draw callback, then set a repeating Cairo source built from that cell, aligned to the fill origin and honouring the pattern phase. **CGContextSetPatternPhase** records the phase.
- **Colored** patterns paint their own colours in the cell.
- **CGColorSpaceCreatePattern** now returns a pattern colour space (a new `OPColorSpacePattern`) that reports the pattern model, carries an optional base space, and takes its component count from that base. The context remembers its fill/stroke colour spaces, and an **uncolored** pattern's cell is drawn with the caller's `components` interpreted in that base space.

Adds render tests (`Tests/opal/CGPattern`): a 4x4 cell tiles with a 4-pixel period, checked horizontally and vertically; the pattern colour space's model/component-count/base; and an uncolored pattern tinted through its base space. Verified against Apple CoreGraphics - the tiling period, origin and orientation (including Apple's vertical cell placement) and the colour space properties (colored: pattern model, 0 components, no base; uncolored: pattern model, base's component count, base reported) all match.