### PR TITLE
Fix: reset the colour when setting a fill or stroke colour space

### DIFF
--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -1217,7 +1217,7 @@ void CGContextSetFillColorSpace(CGContextRef ctx, CGColorSpaceRef colorspace)
 
   nc = CGColorSpaceGetNumberOfComponents(colorspace);
   components = calloc(nc+1, sizeof(CGFloat));
-  if (components) {
+  if (!components) {
     NSLog(@"%s: calloc failed", __PRETTY_FUNCTION__);
     return;
   }
@@ -1239,7 +1239,7 @@ void CGContextSetStrokeColorSpace(CGContextRef ctx, CGColorSpaceRef colorspace)
 
   nc = CGColorSpaceGetNumberOfComponents(colorspace);
   components = calloc(nc+1, sizeof(CGFloat));
-  if (components) {
+  if (!components) {
     NSLog(@"%s: calloc failed", __PRETTY_FUNCTION__);
     return;
   }


### PR DESCRIPTION
`CGContextSetFillColorSpace` and `CGContextSetStrokeColorSpace` allocate a components array and then guard it with an inverted null check:

```
components = calloc(nc+1, sizeof(CGFloat));
if (components) {                 // fires on success, not failure
  NSLog(@"...: calloc failed");
  return;
}
```

So on a successful allocation they log "calloc failed" and return without setting anything - the functions never reset the colour - and on an actual allocation failure they would fall through and dereference the null pointer.

Corrected to `if (!components)`. The functions now create the colour space's default opaque, zero-intensity colour and set it, matching CoreGraphics.

Verified against Apple: after `SetFillColorSpace` (or `SetStrokeColorSpace`) the current colour is reset to black (0,0,0,255). A regression test is in #49 (marked hopeful there; passes once this is merged).