### PR TITLE
Feature: implement the CGGeometry dictionary representations

### DIFF
--- a/Source/OpalGraphics/CGGeometry.m
+++ b/Source/OpalGraphics/CGGeometry.m
@@ -23,6 +23,9 @@
    */
 
 #import <Foundation/NSObject.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSValue.h>
+#import <Foundation/NSString.h>
 
 /* Define IN_CGGEOMETRY_C so that the header can provide non-inline
  * versions of the function implementations for us.
@@ -185,38 +188,83 @@ CGRect CGRectUnion(CGRect r1, CGRect r2)
   return rect;
 }
 
+/* The geometry structures serialise to flat dictionaries keyed by "X"/"Y"/
+   "Width"/"Height", matching CoreGraphics. */
+
+static NSNumber *numberForKey(NSDictionary *dict, NSString *key)
+{
+  id value = [dict objectForKey: key];
+  return [value isKindOfClass: [NSNumber class]] ? value : nil;
+}
+
 CFDictionaryRef CGPointCreateDictionaryRepresentation(CGPoint point)
 {
-  // FIXME: implement
-  return nil;
-}  
+  return (CFDictionaryRef)[[NSDictionary alloc] initWithObjectsAndKeys:
+    [NSNumber numberWithDouble: point.x], @"X",
+    [NSNumber numberWithDouble: point.y], @"Y",
+    nil];
+}
 
 bool CGPointMakeWithDictionaryRepresentation(CFDictionaryRef dict, CGPoint *point)
 {
-  // FIXME: implement
-  return false;
+  NSDictionary *d = (NSDictionary *)dict;
+  NSNumber *x = numberForKey(d, @"X");
+  NSNumber *y = numberForKey(d, @"Y");
+  if (point == NULL || x == nil || y == nil)
+    {
+      return false;
+    }
+  point->x = [x doubleValue];
+  point->y = [y doubleValue];
+  return true;
 }
 
 CFDictionaryRef CGSizeCreateDictionaryRepresentation(CGSize size)
 {
-  // FIXME: implement
-  return nil;
+  return (CFDictionaryRef)[[NSDictionary alloc] initWithObjectsAndKeys:
+    [NSNumber numberWithDouble: size.width], @"Width",
+    [NSNumber numberWithDouble: size.height], @"Height",
+    nil];
 }
 
 bool CGSizeMakeWithDictionaryRepresentation(CFDictionaryRef dict, CGSize *size)
 {
-  // FIXME: implement
-  return false;
+  NSDictionary *d = (NSDictionary *)dict;
+  NSNumber *w = numberForKey(d, @"Width");
+  NSNumber *h = numberForKey(d, @"Height");
+  if (size == NULL || w == nil || h == nil)
+    {
+      return false;
+    }
+  size->width = [w doubleValue];
+  size->height = [h doubleValue];
+  return true;
 }
 
 CFDictionaryRef CGRectCreateDictionaryRepresentation(CGRect rect)
 {
-  // FIXME: implement
-  return nil;
+  return (CFDictionaryRef)[[NSDictionary alloc] initWithObjectsAndKeys:
+    [NSNumber numberWithDouble: rect.origin.x], @"X",
+    [NSNumber numberWithDouble: rect.origin.y], @"Y",
+    [NSNumber numberWithDouble: rect.size.width], @"Width",
+    [NSNumber numberWithDouble: rect.size.height], @"Height",
+    nil];
 }
 
 bool CGRectMakeWithDictionaryRepresentation(CFDictionaryRef dict, CGRect *rect)
 {
-  // FIXME: implement
-  return false;
+  NSDictionary *d = (NSDictionary *)dict;
+  NSNumber *x = numberForKey(d, @"X");
+  NSNumber *y = numberForKey(d, @"Y");
+  NSNumber *w = numberForKey(d, @"Width");
+  NSNumber *h = numberForKey(d, @"Height");
+  if (rect == NULL || x == nil || y == nil || w == nil || h == nil)
+    {
+      return false;
+    }
+  rect->origin.x = [x doubleValue];
+  rect->origin.y = [y doubleValue];
+  rect->size.width = [w doubleValue];
+  rect->size.height = [h doubleValue];
+  return true;
 }

--- a/Tests/opal/CGGeometryDict/geomdict.m
+++ b/Tests/opal/CGGeometryDict/geomdict.m
@@ -1,0 +1,74 @@
+/* The dictionary representations of CGPoint/CGSize/CGRect use flat "X"/"Y"/
+   "Width"/"Height" keys, round-trip through CG..MakeWithDictionaryRepresentation,
+   and reject a dictionary that is missing keys.  The keys and behaviour match
+   Apple CoreGraphics.  The dictionaries are Foundation dictionaries. */
+#include "Testing.h"
+
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSValue.h>
+#include <Foundation/NSString.h>
+
+#include <CoreGraphics/CGGeometry.h>
+
+int main(void)
+{
+  START_SET("CGGeometry point dictionary")
+
+  NSDictionary *pd = (NSDictionary *)
+    CGPointCreateDictionaryRepresentation(CGPointMake(3, 4));
+  PASS(pd != nil, "a point dictionary is created");
+  PASS([[pd objectForKey: @"X"] doubleValue] == 3
+       && [[pd objectForKey: @"Y"] doubleValue] == 4,
+       "the point dictionary uses X and Y keys");
+
+  CGPoint p;
+  PASS(CGPointMakeWithDictionaryRepresentation((CFDictionaryRef)pd, &p)
+       && p.x == 3 && p.y == 4,
+       "the point round-trips");
+
+  END_SET("CGGeometry point dictionary")
+
+  START_SET("CGGeometry size dictionary")
+
+  NSDictionary *sd = (NSDictionary *)
+    CGSizeCreateDictionaryRepresentation(CGSizeMake(5, 6));
+  PASS([[sd objectForKey: @"Width"] doubleValue] == 5
+       && [[sd objectForKey: @"Height"] doubleValue] == 6,
+       "the size dictionary uses Width and Height keys");
+
+  CGSize s;
+  PASS(CGSizeMakeWithDictionaryRepresentation((CFDictionaryRef)sd, &s)
+       && s.width == 5 && s.height == 6,
+       "the size round-trips");
+
+  END_SET("CGGeometry size dictionary")
+
+  START_SET("CGGeometry rect dictionary")
+
+  NSDictionary *rd = (NSDictionary *)
+    CGRectCreateDictionaryRepresentation(CGRectMake(1, 2, 7, 8));
+  PASS([[rd objectForKey: @"X"] doubleValue] == 1
+       && [[rd objectForKey: @"Y"] doubleValue] == 2
+       && [[rd objectForKey: @"Width"] doubleValue] == 7
+       && [[rd objectForKey: @"Height"] doubleValue] == 8,
+       "the rect dictionary uses X, Y, Width and Height keys");
+
+  CGRect r;
+  PASS(CGRectMakeWithDictionaryRepresentation((CFDictionaryRef)rd, &r)
+       && r.origin.x == 1 && r.origin.y == 2
+       && r.size.width == 7 && r.size.height == 8,
+       "the rect round-trips");
+
+  END_SET("CGGeometry rect dictionary")
+
+  START_SET("CGGeometry dictionary rejects bad input")
+
+  CGPoint q;
+  PASS(!CGPointMakeWithDictionaryRepresentation(
+         (CFDictionaryRef)[NSDictionary dictionary], &q),
+       "a dictionary missing the keys is rejected");
+
+  END_SET("CGGeometry dictionary rejects bad input")
+
+  return 0;
+}


### PR DESCRIPTION
Implements the CGGeometry dictionary representations, which were stubs: `CGPointCreateDictionaryRepresentation` / `CGSizeCreateDictionaryRepresentation` / `CGRectCreateDictionaryRepresentation` returned nil and the matching `…MakeWithDictionaryRepresentation` functions returned false, so a geometry structure could not be serialised to or from a dictionary.

They now build and read flat dictionaries keyed by `X`/`Y`/`Width`/`Height`, matching CoreGraphics:

- point → `{X, Y}`
- size → `{Width, Height}`
- rect → `{X, Y, Width, Height}`

The `MakeWith…` functions return false when a required key is missing or the output pointer is NULL.

Verified against Apple CoreGraphics (same keys, round-trip, and rejection of a malformed dictionary). Adds tests for the keys, the round-trip, and rejection.