### PR TITLE
Feature: report image properties from the PNG and JPEG sources

### DIFF
--- a/Headers/CoreGraphics/CGImage.h
+++ b/Headers/CoreGraphics/CGImage.h
@@ -89,6 +89,12 @@ extern const CFStringRef kCGImagePropertyOrientation;
 
 extern const CFStringRef kCGImagePropertyPixelHeight;
 extern const CFStringRef kCGImagePropertyPixelWidth;
+extern const CFStringRef kCGImagePropertyDepth;
+extern const CFStringRef kCGImagePropertyHasAlpha;
+extern const CFStringRef kCGImagePropertyColorModel;
+extern const CFStringRef kCGImagePropertyColorModelRGB;
+extern const CFStringRef kCGImagePropertyColorModelGray;
+extern const CFStringRef kCGImagePropertyColorModelCMYK;
 
 extern const CFStringRef kCGImagePropertyTIFFDictionary;
 extern const CFStringRef kCGImagePropertyGIFDictionary;

--- a/Source/OpalGraphics/CGImage.m
+++ b/Source/OpalGraphics/CGImage.m
@@ -42,6 +42,18 @@ const CFStringRef kCGImagePropertyPixelHeight =
   OPALSTR("kCGImagePropertyPixelHeight");
 const CFStringRef kCGImagePropertyPixelWidth =
   OPALSTR("kCGImagePropertyPixelWidth");
+const CFStringRef kCGImagePropertyDepth =
+  OPALSTR("kCGImagePropertyDepth");
+const CFStringRef kCGImagePropertyHasAlpha =
+  OPALSTR("kCGImagePropertyHasAlpha");
+const CFStringRef kCGImagePropertyColorModel =
+  OPALSTR("kCGImagePropertyColorModel");
+const CFStringRef kCGImagePropertyColorModelRGB =
+  OPALSTR("RGB");
+const CFStringRef kCGImagePropertyColorModelGray =
+  OPALSTR("Gray");
+const CFStringRef kCGImagePropertyColorModelCMYK =
+  OPALSTR("CMYK");
 
 const CFStringRef kCGImagePropertyTIFFDictionary =
   OPALSTR("kCGImagePropertyTIFFDictionary");

--- a/Source/OpalGraphics/image/OPImageCodecJPEG.m
+++ b/Source/OpalGraphics/image/OPImageCodecJPEG.m
@@ -366,12 +366,50 @@ static void gs_jpeg_memory_dest_destroy (j_compress_ptr cinfo)
   
 - (NSDictionary*)propertiesWithOptions: (NSDictionary*)opts
 {
-  return [NSDictionary dictionary];
+  return [self propertiesWithOptions: opts atIndex: 0];
 }
 
 - (NSDictionary*)propertiesWithOptions: (NSDictionary*)opts atIndex: (size_t)index
 {
-  return [NSDictionary dictionary];  
+  NSMutableDictionary *props = [NSMutableDictionary dictionary];
+  struct jpeg_decompress_struct cinfo;
+  struct gs_jpeg_error_mgr jerrMgr;
+
+  memset((void*)&cinfo, 0, sizeof(struct jpeg_decompress_struct));
+  gs_jpeg_error_mgr_create((j_common_ptr)&cinfo, &jerrMgr);
+  jpeg_create_decompress(&cinfo);
+  OPDataProviderRewind(dp);
+  gs_jpeg_memory_src_create(&cinfo, dp);
+
+  NS_DURING
+  {
+    jpeg_read_header(&cinfo, TRUE);
+
+    [props setObject: [NSNumber numberWithUnsignedInt: cinfo.image_width]
+             forKey: (NSString*)kCGImagePropertyPixelWidth];
+    [props setObject: [NSNumber numberWithUnsignedInt: cinfo.image_height]
+             forKey: (NSString*)kCGImagePropertyPixelHeight];
+    [props setObject: [NSNumber numberWithInt: cinfo.data_precision]
+             forKey: (NSString*)kCGImagePropertyDepth];
+
+    CFStringRef model = kCGImagePropertyColorModelRGB;
+    if (cinfo.num_components == 1)
+      model = kCGImagePropertyColorModelGray;
+    else if (cinfo.num_components == 4)
+      model = kCGImagePropertyColorModelCMYK;
+    [props setObject: (NSString*)model
+             forKey: (NSString*)kCGImagePropertyColorModel];
+  }
+  NS_HANDLER
+  {
+    /* fall through with whatever was collected */
+  }
+  NS_ENDHANDLER
+
+  gs_jpeg_memory_src_destroy(&cinfo);
+  jpeg_destroy_decompress(&cinfo);
+  OPDataProviderRewind(dp);
+  return props;
 }
 
 - (size_t)count

--- a/Source/OpalGraphics/image/OPImageCodecPNG.m
+++ b/Source/OpalGraphics/image/OPImageCodecPNG.m
@@ -145,12 +145,65 @@ static bool opal_has_png_header(CGDataProviderRef dp)
 
 - (NSDictionary*)propertiesWithOptions: (NSDictionary*)opts
 {
-  return [NSDictionary dictionary];
+  return [self propertiesWithOptions: opts atIndex: 0];
 }
 
 - (NSDictionary*)propertiesWithOptions: (NSDictionary*)opts atIndex: (size_t)index
 {
-  return [NSDictionary dictionary];  
+  NSMutableDictionary *props = [NSMutableDictionary dictionary];
+  png_structp png_struct = NULL;
+  png_infop png_info = NULL;
+
+  OPDataProviderRewind(dp);
+  NS_DURING
+  {
+    png_struct = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL,
+      opal_png_error_fn, opal_png_warning_fn);
+    if (png_struct)
+    {
+      png_info = png_create_info_struct(png_struct);
+    }
+    if (png_struct && png_info)
+    {
+      png_set_read_fn(png_struct, dp, opal_png_reader_func);
+      png_read_info(png_struct, png_info);
+
+      const png_uint_32 width = png_get_image_width(png_struct, png_info);
+      const png_uint_32 height = png_get_image_height(png_struct, png_info);
+      const int depth = png_get_bit_depth(png_struct, png_info);
+      const int type = png_get_color_type(png_struct, png_info);
+
+      [props setObject: [NSNumber numberWithUnsignedLong: width]
+               forKey: (NSString*)kCGImagePropertyPixelWidth];
+      [props setObject: [NSNumber numberWithUnsignedLong: height]
+               forKey: (NSString*)kCGImagePropertyPixelHeight];
+      [props setObject: [NSNumber numberWithInt: depth]
+               forKey: (NSString*)kCGImagePropertyDepth];
+
+      BOOL isGray = (type == PNG_COLOR_TYPE_GRAY
+                     || type == PNG_COLOR_TYPE_GRAY_ALPHA);
+      [props setObject: (NSString*)(isGray ? kCGImagePropertyColorModelGray
+                                           : kCGImagePropertyColorModelRGB)
+               forKey: (NSString*)kCGImagePropertyColorModel];
+
+      BOOL hasAlpha = (type & PNG_COLOR_MASK_ALPHA) != 0
+        || png_get_valid(png_struct, png_info, PNG_INFO_tRNS);
+      [props setObject: [NSNumber numberWithBool: hasAlpha]
+               forKey: (NSString*)kCGImagePropertyHasAlpha];
+    }
+  }
+  NS_HANDLER
+  {
+    /* fall through with whatever was collected */
+  }
+  NS_ENDHANDLER
+
+  if (png_struct)
+  {
+    png_destroy_read_struct(&png_struct, png_info ? &png_info : NULL, NULL);
+  }
+  OPDataProviderRewind(dp);
+  return props;
 }
 
 - (size_t)count

--- a/Tests/opal/CGImageProperties/properties.m
+++ b/Tests/opal/CGImageProperties/properties.m
@@ -1,0 +1,94 @@
+/* CGImageSourceCopyPropertiesAtIndex reports an encoded image's metadata:
+   pixel width and height, bits per component (Depth), colour model and, for
+   formats that carry it, whether the image has alpha.  A PNG and a JPEG are
+   generated in memory and their properties are read back.  Keys and values
+   match Apple CoreGraphics.  The dictionaries are Foundation dictionaries. */
+#include "Testing.h"
+
+#include <Foundation/NSData.h>
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSValue.h>
+#include <Foundation/NSString.h>
+
+#include <CoreGraphics/CGImage.h>
+#include <CoreGraphics/CGImageSource.h>
+#include <CoreGraphics/CGImageDestination.h>
+#include <CoreGraphics/CGBitmapContext.h>
+#include <CoreGraphics/CGContext.h>
+#include <CoreGraphics/CGColorSpace.h>
+#include <CoreGraphics/CGColor.h>
+
+/* A solid green w*h image drawn with device colours. */
+static CGImageRef makeImage(CGColorSpaceRef dev, int w, int h)
+{
+  CGContextRef c = CGBitmapContextCreate(NULL, w, h, 8, w*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGFloat green[] = {0, 1, 0, 1};
+  CGColorRef col = CGColorCreate(dev, green);
+  CGContextSetFillColorWithColor(c, col);
+  CGContextFillRect(c, CGRectMake(0, 0, w, h));
+  CGColorRelease(col);
+  CGImageRef img = CGBitmapContextCreateImage(c);
+  CGContextRelease(c);
+  return img;
+}
+
+static NSData *encode(CGImageRef img, NSString *type)
+{
+  NSMutableData *data = [NSMutableData data];
+  CGImageDestinationRef dst =
+    CGImageDestinationCreateWithData((CFMutableDataRef)data,
+      (CFStringRef)type, 1, NULL);
+  CGImageDestinationAddImage(dst, img, NULL);
+  CGImageDestinationFinalize(dst);
+  return data;
+}
+
+static NSDictionary *propsFor(NSData *data)
+{
+  CGImageSourceRef src = CGImageSourceCreateWithData((CFDataRef)data, NULL);
+  return (NSDictionary *)CGImageSourceCopyPropertiesAtIndex(src, 0, NULL);
+}
+
+int main(void)
+{
+  CGColorSpaceRef dev = CGColorSpaceCreateDeviceRGB();
+
+  START_SET("CGImageSource PNG properties")
+
+  NSData *png = encode(makeImage(dev, 3, 5), @"public.png");
+  NSDictionary *p = propsFor(png);
+  PASS(p != nil && [p count] > 0, "PNG properties are returned");
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyPixelWidth] intValue] == 3,
+       "the PNG pixel width is reported");
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyPixelHeight] intValue] == 5,
+       "the PNG pixel height is reported");
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyDepth] intValue] == 8,
+       "the PNG bit depth is reported");
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyColorModel]
+         isEqual: (NSString*)kCGImagePropertyColorModelRGB],
+       "the PNG colour model is RGB");
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyHasAlpha] boolValue] == YES,
+       "the PNG reports that it has alpha");
+
+  END_SET("CGImageSource PNG properties")
+
+  START_SET("CGImageSource JPEG properties")
+
+  NSData *jpg = encode(makeImage(dev, 7, 4), @"public.jpeg");
+  NSDictionary *p = propsFor(jpg);
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyPixelWidth] intValue] == 7,
+       "the JPEG pixel width is reported");
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyPixelHeight] intValue] == 4,
+       "the JPEG pixel height is reported");
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyDepth] intValue] == 8,
+       "the JPEG bit depth is reported");
+  PASS([[p objectForKey: (NSString*)kCGImagePropertyColorModel]
+         isEqual: (NSString*)kCGImagePropertyColorModelRGB],
+       "the JPEG colour model is RGB");
+
+  END_SET("CGImageSource JPEG properties")
+
+  CGColorSpaceRelease(dev);
+  return 0;
+}


### PR DESCRIPTION
`CGImageSourceCopyProperties` / `CopyPropertiesAtIndex` returned an empty dictionary because the PNG and JPEG codecs reported nothing. They now read the image header and return the standard metadata:

- `kCGImagePropertyPixelWidth`, `kCGImagePropertyPixelHeight`
- `kCGImagePropertyDepth` (bits per component)
- `kCGImagePropertyColorModel` (`RGB` / `Gray` / `CMYK`)
- `kCGImagePropertyHasAlpha` (PNG)

Also adds the missing property key/value constants (`Depth`, `HasAlpha`, `ColorModel`, and the `ColorModel` values `RGB`/`Gray`/`CMYK`). The PNG IHDR and the JPEG header are read without consuming the data provider - it is rewound afterwards, so decoding still works.

Verified against Apple CoreGraphics (a generated 3x5 PNG reports width 3, height 5, depth 8, ColorModel RGB, HasAlpha true; a 7x4 JPEG reports width 7, height 4, depth 8, ColorModel RGB). Adds tests; the CGImageIO round-trip is unaffected.

DPI is not included: CoreGraphics only reports it when the file carries density information (a PNG `pHYs` chunk or JPEG JFIF density), which these images do not.