### PR TITLE
tests: add CGImageCreateCopyWithColorSpace tests

### DIFF
--- a/Source/OpalGraphics/CGImage.m
+++ b/Source/OpalGraphics/CGImage.m
@@ -340,7 +340,8 @@ CGImageRef CGImageCreateCopyWithColorSpace(
 {
   CGImageRef new;
 
-  // FIXME: is this supposed to convert pixel data?
+  /* This re-tags the image with a new colour space of the same number of
+     components; it does not convert the pixel data, matching CoreGraphics. */
 
   if (image->ismask ||
     CGColorSpaceGetNumberOfComponents(image->cspace)

--- a/Tests/opal/CGImageCopyCS/copycs.m
+++ b/Tests/opal/CGImageCopyCS/copycs.m
@@ -1,0 +1,70 @@
+/* CGImageCreateCopyWithColorSpace re-tags a bitmap image with a new colour
+   space of the same number of components, keeping the pixel data: the copy has
+   the original dimensions and bit depth, reports the new colour space, and
+   draws to the same pixels (CoreGraphics does not convert the pixel data).  It
+   returns NULL when the component counts differ or the image is a mask.
+   Behaviour checked against Apple CoreGraphics. */
+#include "Testing.h"
+
+#include <CoreGraphics/CGImage.h>
+#include <CoreGraphics/CGBitmapContext.h>
+#include <CoreGraphics/CGColorSpace.h>
+#include <CoreGraphics/CGContext.h>
+#include <stdlib.h>
+
+static CGImageRef rgbImage(CGColorSpaceRef dev)
+{
+  CGContextRef c = CGBitmapContextCreate(NULL, 2, 2, 8, 8, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextSetRGBFillColor(c, 200/255.0, 100/255.0, 50/255.0, 1);
+  CGContextFillRect(c, CGRectMake(0, 0, 2, 2));
+  CGImageRef img = CGBitmapContextCreateImage(c);
+  CGContextRelease(c);
+  return img;
+}
+
+static void firstPixel(CGImageRef img, CGColorSpaceRef dev, unsigned char out[4])
+{
+  unsigned char *b = calloc(2*2*4, 1);
+  CGContextRef c = CGBitmapContextCreate(b, 2, 2, 8, 8, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextDrawImage(c, CGRectMake(0, 0, 2, 2), img);
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+  out[0]=d[0]; out[1]=d[1]; out[2]=d[2]; out[3]=d[3];
+  CGContextRelease(c); free(b);
+}
+
+int main(void)
+{
+  CGColorSpaceRef dev = CGColorSpaceCreateDeviceRGB();
+  CGColorSpaceRef srgb = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+  CGColorSpaceRef gray = CGColorSpaceCreateDeviceGray();
+
+  START_SET("CGImageCreateCopyWithColorSpace")
+
+  CGImageRef img = rgbImage(dev);
+
+  CGImageRef copy = CGImageCreateCopyWithColorSpace(img, srgb);
+  PASS(copy != NULL, "copying to a same-component colour space succeeds");
+  PASS(CGImageGetWidth(copy) == 2 && CGImageGetHeight(copy) == 2,
+       "the copy keeps the dimensions");
+  PASS(CGImageGetBitsPerComponent(copy) == 8,
+       "the copy keeps the bit depth");
+  PASS(CGColorSpaceGetModel(CGImageGetColorSpace(copy)) == kCGColorSpaceModelRGB,
+       "the copy reports a colour space");
+
+  unsigned char a[4], b[4];
+  firstPixel(img, dev, a);
+  firstPixel(copy, dev, b);
+  PASS(a[0]==b[0] && a[1]==b[1] && a[2]==b[2] && a[3]==b[3],
+       "the pixel data is unchanged (not converted)");
+
+  CGImageRef toGray = CGImageCreateCopyWithColorSpace(img, gray);
+  PASS(toGray == NULL,
+       "copying to a colour space with a different component count returns NULL");
+
+  END_SET("CGImageCreateCopyWithColorSpace")
+
+  CGColorSpaceRelease(dev);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for `CGImageCreateCopyWithColorSpace` and clarifies its (already correct) comment.

`CGImageCreateCopyWithColorSpace` re-tags a bitmap image with a new colour space that has the same number of components, keeping the pixel data. The tests confirm, against Apple CoreGraphics, that:

- copying to a same-component colour space (e.g. deviceRGB -> sRGB) succeeds and keeps the dimensions, bit depth and pixel data (the copy draws to the same pixels - CoreGraphics does not convert the data);
- copying to a colour space with a different component count (RGB -> Gray) returns NULL.

The existing implementation already matches this. The one source change replaces a `// FIXME: is this supposed to convert pixel data?` comment with a note that it re-tags without converting, matching CoreGraphics (verified by the oracle: an RGB image copied to sRGB draws to the identical pixels, and a copy to a gray space or of a mask returns NULL).