### PR TITLE
Feature: implement CGContextDrawTiledImage

### DIFF
--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -1437,6 +1437,36 @@ void CGContextDrawTiledImage(CGContextRef ctx, CGRect rect, CGImageRef image)
 {
   OPLOGCALL("ctx /*%p*/, CGRectMake(%g, %g, %g, %g), <image>", ctx, rect.origin.x,
             rect.origin.y, rect.size.width, rect.size.height)
+
+  const double tw = rect.size.width;
+  const double th = rect.size.height;
+  if (tw <= 0 || th <= 0)
+    {
+      OPRESTORELOGGING()
+      return;
+    }
+
+  cairo_surface_t *surface =
+    opal_CGImageGetSurfaceForImage(image, cairo_get_target(ctx->ct));
+  CGRect srcRect = opal_CGImageGetSourceRect(image);
+
+  /* Tile across the current clip region.  Each tile is rect.size big, one tile
+     is anchored at rect.origin, and the pattern repeats in both directions. */
+  double cx1, cy1, cx2, cy2;
+  cairo_clip_extents(ctx->ct, &cx1, &cy1, &cx2, &cy2);
+
+  const double startX = rect.origin.x + floor((cx1 - rect.origin.x) / tw) * tw;
+  const double startY = rect.origin.y + floor((cy1 - rect.origin.y) / th) * th;
+
+  for (double y = startY; y < cy2; y += th)
+    {
+      for (double x = startX; x < cx2; x += tw)
+        {
+          opal_draw_surface_in_rect(ctx, CGRectMake(x, y, tw, th),
+            surface, srcRect);
+        }
+    }
+
   OPRESTORELOGGING()
 }
 

--- a/Tests/opal/CGTiledImage/tiled.m
+++ b/Tests/opal/CGTiledImage/tiled.m
@@ -1,0 +1,60 @@
+/* CGContextDrawTiledImage tiles an image across the clip region.  A 4x4 tile
+   (left half green, right half blue) is tiled over a 12x12 context; the tile
+   repeats with a period of 4 and fills the whole context.  Checked against
+   Apple CoreGraphics. */
+#include "Testing.h"
+
+#include <CoreGraphics/CGContext.h>
+#include <CoreGraphics/CGBitmapContext.h>
+#include <CoreGraphics/CGColorSpace.h>
+#include <CoreGraphics/CGImage.h>
+#include <stdlib.h>
+
+#define W 12
+
+static CGImageRef makeTile(CGColorSpaceRef dev)
+{
+  CGContextRef c = CGBitmapContextCreate(NULL, 4, 4, 8, 16, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextSetRGBFillColor(c, 0, 1, 0, 1);
+  CGContextFillRect(c, CGRectMake(0, 0, 2, 4));
+  CGContextSetRGBFillColor(c, 0, 0, 1, 1);
+  CGContextFillRect(c, CGRectMake(2, 0, 2, 4));
+  CGImageRef img = CGBitmapContextCreateImage(c);
+  CGContextRelease(c);
+  return img;
+}
+
+/* green channel and blue channel of a pixel */
+static int G(unsigned char *d, int x, int y) { return d[(y*W + x)*4 + 1]; }
+static int B(unsigned char *d, int x, int y) { return d[(y*W + x)*4 + 2]; }
+
+int main(void)
+{
+  CGColorSpaceRef dev = CGColorSpaceCreateDeviceRGB();
+
+  START_SET("CGContext draw tiled image")
+
+  unsigned char *buf = calloc(W*W*4, 1);
+  CGContextRef c = CGBitmapContextCreate(buf, W, W, 8, W*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextDrawTiledImage(c, CGRectMake(0, 0, 4, 4), makeTile(dev));
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+
+  /* Each 4px tile is green in its left half, blue in its right half. */
+  PASS(G(d,0,6) > 200 && G(d,1,6) > 200, "the first tile's left half is green");
+  PASS(B(d,2,6) > 200 && B(d,3,6) > 200, "the first tile's right half is blue");
+  PASS(G(d,4,6) > 200 && G(d,5,6) > 200, "the pattern repeats a tile later");
+  PASS(B(d,6,6) > 200 && B(d,7,6) > 200, "the right half repeats too");
+  PASS(G(d,8,6) > 200 && B(d,10,6) > 200, "tiling continues across the context");
+
+  /* The tile fills the whole context, not just the origin tile. */
+  PASS(B(d,10,10) > 200, "a far corner is filled by the tiling");
+
+  CGContextRelease(c); free(buf);
+
+  END_SET("CGContext draw tiled image")
+
+  CGColorSpaceRelease(dev);
+  return 0;
+}


### PR DESCRIPTION
Implements `CGContextDrawTiledImage`, which was a no-op.

It now tiles the image across the current clip region: one tile is anchored at the origin of the `rect` argument, each tile is `rect`'s size, and the image repeats in both directions to fill the clip. Each tile is drawn with the existing `opal_draw_surface_in_rect` helper, so scaling and orientation match `CGContextDrawImage`.

Verified against Apple CoreGraphics: a 4x4 tile (left half green, right half blue) tiled over a 12x12 context repeats with a 4-pixel period (green at x 0-1/4-5/8-9, blue at 2-3/6-7/10-11) and fills the whole context, including the far corner. Adds a test covering the period, coverage and orientation.