### PR TITLE
Feature: implement CGContextClipToMask

### DIFF
--- a/Source/OpalGraphics/CGContext-private.h
+++ b/Source/OpalGraphics/CGContext-private.h
@@ -47,6 +47,7 @@ struct ct_additions
   CGFloat font_size;
   CGFloat char_spacing;
   CGTextDrawingMode text_mode;
+  cairo_pattern_t *clip_mask;
 };
 
 @interface CGContext : NSObject

--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -31,8 +31,11 @@
 #import "CGContext-private.h"
 #import "CGGradient-private.h"
 #import "CGColor-private.h"
+#import "CGDataProvider-private.h"
 #import "cairo/CairoFont.h"
 #import "OPLogging.h"
+
+#include <math.h>
 
 /* The default (opaque black) color in a Cairo context,
  * used if no other color is set on the context yet */
@@ -40,6 +43,9 @@ static cairo_pattern_t *default_cp;
 
 extern cairo_surface_t *opal_CGImageGetSurfaceForImage(CGImageRef img, cairo_surface_t *contextSurface);
 extern CGRect opal_CGImageGetSourceRect(CGImageRef image);
+
+static void opal_mask_begin(CGContextRef ctx);
+static void opal_mask_end(CGContextRef ctx);
 
 static inline void set_color(cairo_pattern_t **cp, CGColorRef clr, double alpha);
 static void start_shadow(CGContextRef ctx);
@@ -107,6 +113,7 @@ static void end_shadow(CGContextRef ctx, CGRect bounds);
     CGColorRelease(ctadd->shadow_color);
     cairo_pattern_destroy(ctadd->shadow_cp);
     CGFontRelease(ctadd->font);
+    if (ctadd->clip_mask) cairo_pattern_destroy(ctadd->clip_mask);
     next = ctadd->next;
     free(ctadd);
     ctadd = next;
@@ -333,6 +340,7 @@ void CGContextSaveGState(CGContextRef ctx)
   cairo_pattern_reference(ctadd->fill_cp);
   CGColorRetain(ctadd->stroke_color);
   cairo_pattern_reference(ctadd->stroke_cp);
+  if (ctadd->clip_mask) cairo_pattern_reference(ctadd->clip_mask);
   ctadd->next = ctx->add;
   ctx->add = ctadd;
   OPRESTORELOGGING()
@@ -357,6 +365,7 @@ void CGContextRestoreGState(CGContextRef ctx)
   cairo_pattern_destroy(ctx->add->fill_cp);
   CGColorRelease(ctx->add->stroke_color);
   cairo_pattern_destroy(ctx->add->stroke_cp);
+  if (ctx->add->clip_mask) cairo_pattern_destroy(ctx->add->clip_mask);
   ctadd = ctx->add->next;
   free(ctx->add);
   ctx->add = ctadd;
@@ -791,13 +800,15 @@ void CGContextStrokePath(CGContextRef ctx)
     start_shadow(ctx);
   }
 
+  opal_mask_begin(ctx);
   if(ctx->add->stroke_cp)
     cairo_set_source(ctx->ct, ctx->add->stroke_cp);
   else
     cairo_set_source(ctx->ct, default_cp);
 
   cairo_stroke(ctx->ct);
-  
+  opal_mask_end(ctx);
+
   if (ctx->add->shadow_cp) {
     end_shadow(ctx, CGRectMake(0,0,500,500)); //FIXME
   }
@@ -826,6 +837,7 @@ static void fill_path(CGContextRef ctx, int eorule, int preserve)
   if (ctx->add->shadow_cp) {
     start_shadow(ctx);
   }
+  opal_mask_begin(ctx);
   if (ctx->add->fill_cp)
     cairo_set_source(ctx->ct, ctx->add->fill_cp);
   else
@@ -836,6 +848,7 @@ static void fill_path(CGContextRef ctx, int eorule, int preserve)
     cairo_set_fill_rule(ctx->ct, CAIRO_FILL_RULE_WINDING);
 
   cairo_fill_preserve(ctx->ct);
+  opal_mask_end(ctx);
 
   if (!preserve) cairo_new_path(ctx->ct);
   
@@ -1062,18 +1075,102 @@ void CGContextClipToRects(CGContextRef ctx, const CGRect rects[], size_t count)
   OPRESTORELOGGING()
 }
 
+/* Build an alpha (A8) coverage pattern from a mask image, mapped into rect.
+   For an image mask a sample of 0 paints fully and 255 not at all; for a normal
+   image the alpha channel (or the luminance, if there is no alpha) is the
+   coverage. */
+static cairo_pattern_t *opal_CreateMaskPattern(CGRect rect, CGImageRef mask)
+{
+  const size_t mw = CGImageGetWidth(mask);
+  const size_t mh = CGImageGetHeight(mask);
+  const size_t sbpr = CGImageGetBytesPerRow(mask);
+  const size_t sbpp = CGImageGetBitsPerPixel(mask) / 8;
+  const bool isMask = CGImageIsMask(mask);
+  const CGImageAlphaInfo alpha = CGImageGetAlphaInfo(mask);
+  const bool hasAlpha = !isMask
+    && (alpha == kCGImageAlphaPremultipliedLast || alpha == kCGImageAlphaLast
+        || alpha == kCGImageAlphaPremultipliedFirst || alpha == kCGImageAlphaFirst);
+  const bool alphaFirst = (alpha == kCGImageAlphaPremultipliedFirst
+                           || alpha == kCGImageAlphaFirst);
+
+  const unsigned char *src = OPDataProviderGetBytePointer(CGImageGetDataProvider(mask));
+  if (src == NULL || mw == 0 || mh == 0)
+    {
+      return NULL;
+    }
+
+  cairo_surface_t *asurf = cairo_image_surface_create(CAIRO_FORMAT_A8, mw, mh);
+  cairo_surface_flush(asurf);
+  unsigned char *adata = cairo_image_surface_get_data(asurf);
+  const int astride = cairo_image_surface_get_stride(asurf);
+
+  for (size_t y = 0; y < mh; y++)
+    {
+      for (size_t x = 0; x < mw; x++)
+        {
+          const unsigned char *pixel = src + y * sbpr + x * sbpp;
+          unsigned char sample;
+          if (hasAlpha)
+            sample = alphaFirst ? pixel[0] : pixel[sbpp - 1];
+          else
+            sample = pixel[0]; /* image mask or single-component image */
+          adata[y * astride + x] = isMask ? (255 - sample) : sample;
+        }
+    }
+  cairo_surface_mark_dirty(asurf);
+
+  cairo_pattern_t *pat = cairo_pattern_create_for_surface(asurf);
+  cairo_surface_destroy(asurf);
+
+  /* Map user space to the mask's pixels: the mask covers rect, flipped because
+     the surface is top-down while the context is y-up. */
+  cairo_matrix_t m;
+  cairo_matrix_init_identity(&m);
+  cairo_matrix_scale(&m, mw / rect.size.width, mh / rect.size.height);
+  cairo_matrix_translate(&m, -rect.origin.x, -rect.origin.y);
+  cairo_matrix_scale(&m, 1, -1);
+  cairo_matrix_translate(&m, 0, -rect.size.height);
+  cairo_pattern_set_matrix(pat, &m);
+
+  return pat;
+}
+
+/* If a clip mask is active, redirect drawing to a temporary group. */
+static void opal_mask_begin(CGContextRef ctx)
+{
+  if (ctx->add->clip_mask)
+    {
+      cairo_push_group(ctx->ct);
+    }
+}
+
+/* If a clip mask is active, composite the group through the mask. */
+static void opal_mask_end(CGContextRef ctx)
+{
+  if (ctx->add->clip_mask)
+    {
+      cairo_pop_group_to_source(ctx->ct);
+      cairo_mask(ctx->ct, ctx->add->clip_mask);
+    }
+}
+
 void CGContextClipToMask(CGContextRef ctx, CGRect rect, CGImageRef mask)
 {
-  OPLOGCALL("ctx /*%p*/, CGRectMake(%g, %g, %g, %g), <mask>", ctx, 
+  OPLOGCALL("ctx /*%p*/, CGRectMake(%g, %g, %g, %g), <mask>", ctx,
             rect.origin.x, rect.origin.y,
             rect.size.width, rect.size.height)
-  /* Attach a temporay image mask to the surface.
-     Then, all drawing needs a: 
-       push_group()
-       do the drawing
-       pop_group_to_source();
-       mask()
-  */
+  if (mask != NULL && rect.size.width > 0 && rect.size.height > 0)
+    {
+      cairo_pattern_t *pat = opal_CreateMaskPattern(rect, mask);
+      if (pat)
+        {
+          if (ctx->add->clip_mask)
+            {
+              cairo_pattern_destroy(ctx->add->clip_mask);
+            }
+          ctx->add->clip_mask = pat;
+        }
+    }
   OPRESTORELOGGING()
 }
 
@@ -1410,7 +1507,7 @@ void opal_draw_surface_in_rect(CGContextRef ctxt, CGRect rect, cairo_surface_t *
 
   cairo_set_source(destCairo, pattern);
   cairo_pattern_destroy(pattern);
-  
+
   // FIXME: What is the fastest way to draw? cairo_paint? clip? fill a rect?
   cairo_rectangle(destCairo, 0, 0,
     rect.size.width, rect.size.height);

--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -1500,6 +1500,12 @@ void opal_draw_surface_in_rect(CGContextRef ctxt, CGRect rect, cairo_surface_t *
   // Do the drawing
 
   cairo_t *destCairo = ctxt->ct;
+
+  /* Render into a group so an active clip mask can be applied afterwards, in
+     the untranslated user space the mask was set up in. */
+  const bool masked = (ctxt->add->clip_mask != NULL);
+  if (masked) cairo_push_group(destCairo);
+
   cairo_save(destCairo);
 
   cairo_set_operator(destCairo, CAIRO_OPERATOR_OVER);
@@ -1515,6 +1521,12 @@ void opal_draw_surface_in_rect(CGContextRef ctxt, CGRect rect, cairo_surface_t *
   cairo_paint_with_alpha(destCairo, ctxt->add->alpha);
 
   cairo_restore(destCairo);
+
+  if (masked)
+    {
+      cairo_pop_group_to_source(destCairo);
+      cairo_mask(destCairo, ctxt->add->clip_mask);
+    }
 }
 
 void CGContextDrawImage(CGContextRef ctx, CGRect rect, CGImageRef image)
@@ -1588,11 +1600,13 @@ void CGContextDrawLinearGradient(
             startPoint.x, startPoint.y, endPoint.x, endPoint.y, options)
   cairo_pattern_t *pat = cairo_pattern_create_linear(startPoint.x, startPoint.y, endPoint.x, endPoint.y);
   opal_AddStops(pat, gradient);
-  
+
+  opal_mask_begin(ctx);
   cairo_set_source(ctx->ct, pat);
   // FIXME: respect CGGradientDrawingOptions
   cairo_paint(ctx->ct);
-  
+  opal_mask_end(ctx);
+
   cairo_pattern_destroy(pat);
   OPRESTORELOGGING()
 }
@@ -1612,11 +1626,13 @@ void CGContextDrawRadialGradient(
   cairo_pattern_t *pat = cairo_pattern_create_radial(startCenter.x, startCenter.y, startRadius,
     endCenter.x, endCenter.y, endRadius);
   opal_AddStops(pat, gradient);
-  
+
+  opal_mask_begin(ctx);
   cairo_set_source(ctx->ct, pat);
   // FIXME: respect CGGradientDrawingOptions
   cairo_paint(ctx->ct);
-  
+  opal_mask_end(ctx);
+
   cairo_pattern_destroy(pat);
   OPRESTORELOGGING()
 }
@@ -1754,6 +1770,7 @@ void CGContextShowText(CGContextRef ctx, const char *string, size_t length)
 
   cairo_set_font_matrix(ctx->ct, &cairotextmatrix);
 
+  opal_mask_begin(ctx);
   if(ctx->add->fill_cp)
     cairo_set_source(ctx->ct, ctx->add->fill_cp);
   else
@@ -1761,12 +1778,14 @@ void CGContextShowText(CGContextRef ctx, const char *string, size_t length)
 
   cairo_show_text(ctx->ct, cString);
 
-
-  // Update the opal text matrix with the distance the current point moved
+  // Update the opal text matrix with the distance the current point moved.
+  // Read it before applying any clip mask, which restores the graphics state.
 
   double dx, dy;
   cairo_get_current_point(ctx->ct, &dx, &dy);
-  
+
+  opal_mask_end(ctx);
+
   CGPoint textPos = CGContextGetTextPosition(ctx);
   CGContextSetTextPosition(ctx, textPos.x + dx, textPos.y + dy);
   // FXIME: scaled?
@@ -1896,17 +1915,19 @@ void CGContextShowGlyphsAtPositions(
 
   // Show the glpyhs
 
+  opal_mask_begin(ctx);
   if(ctx->add->fill_cp)
     cairo_set_source(ctx->ct, ctx->add->fill_cp);
   else
     cairo_set_source(ctx->ct, default_cp);
-  
+
   // FIXME: Report this as a cairo bug.. the following places the glyphs after the first one incorrectly
   //cairo_show_glyphs(ctx->ct, cairoGlyphs, count);
   // WORKAROUND:
   for (int i=0; i<count; i++) {
     cairo_show_glyphs(ctx->ct, &(cairoGlyphs[i]), 1);
   }
+  opal_mask_end(ctx);
   OPRESTORELOGGING()
 }
 

--- a/Tests/opal/CGClipMask/clipmask.m
+++ b/Tests/opal/CGClipMask/clipmask.m
@@ -1,0 +1,94 @@
+/* CGContextClipToMask limits subsequent drawing by an image's coverage.  For an
+   image mask a sample of 0 (black) paints and 255 (white) does not; for a
+   normal image the value (or the alpha) is the coverage.  A green fill is
+   clipped by a half-black/half-white mask - horizontally and vertically - and
+   the painted half is checked.  Which pixels are painted matches Apple
+   CoreGraphics. */
+#include "Testing.h"
+
+#include <CoreGraphics/CGContext.h>
+#include <CoreGraphics/CGBitmapContext.h>
+#include <CoreGraphics/CGColorSpace.h>
+#include <CoreGraphics/CGImage.h>
+#include <CoreGraphics/CGDataProvider.h>
+#include <stdlib.h>
+
+#define W 8
+
+static int A(unsigned char *d, int x, int y) { return d[(y*W + x)*4 + 3]; }
+
+/* An 8x8 one-component image.  vertical=0: left half lo, right half hi;
+   vertical=1: top image rows lo, bottom hi. */
+static CGImageRef halfMask(int lo, int hi, int asMask, int vertical,
+  CGColorSpaceRef gray)
+{
+  unsigned char *m = malloc(W*W);
+  for (int y = 0; y < W; y++)
+    for (int x = 0; x < W; x++)
+      m[y*W+x] = ((vertical ? y : x) < W/2) ? lo : hi;
+  CGDataProviderRef dp = CGDataProviderCreateWithData(NULL, m, W*W, NULL);
+  if (asMask)
+    return CGImageMaskCreate(W, W, 8, 8, W, dp, NULL, false);
+  return CGImageCreate(W, W, 8, 8, W, gray, kCGImageAlphaNone, dp, NULL, false,
+    kCGRenderingIntentDefault);
+}
+
+/* Fill green through the mask; write the four sample alphas. */
+static void fillMasked(CGColorSpaceRef dev, CGImageRef mask,
+  int *left, int *right, int *topDev, int *botDev)
+{
+  unsigned char *buf = calloc(W*W*4, 1);
+  CGContextRef c = CGBitmapContextCreate(buf, W, W, 8, W*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextClipToMask(c, CGRectMake(0, 0, W, W), mask);
+  CGContextSetRGBFillColor(c, 0, 1, 0, 1);
+  CGContextFillRect(c, CGRectMake(0, 0, W, W));
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+  *left = A(d,2,4); *right = A(d,6,4); *topDev = A(d,4,6); *botDev = A(d,4,1);
+  CGContextRelease(c); free(buf);
+}
+
+int main(void)
+{
+  CGColorSpaceRef dev = CGColorSpaceCreateDeviceRGB();
+  CGColorSpaceRef gray = CGColorSpaceCreateDeviceGray();
+  int l, r, t, b;
+
+  START_SET("CGContextClipToMask image mask")
+
+  fillMasked(dev, halfMask(0, 255, 1, 0, gray), &l, &r, &t, &b);
+  PASS(l > 0 && r == 0, "an image mask paints where it is black, not where white");
+
+  fillMasked(dev, halfMask(0, 255, 1, 1, gray), &l, &r, &t, &b);
+  PASS(b > 0 && t == 0,
+       "the mask is oriented like an image (its top maps to the top of the rect)");
+
+  END_SET("CGContextClipToMask image mask")
+
+  START_SET("CGContextClipToMask image")
+
+  fillMasked(dev, halfMask(0, 255, 0, 0, gray), &l, &r, &t, &b);
+  PASS(r > 0 && l == 0,
+       "a normal image paints where it is light, not where dark");
+
+  fillMasked(dev, halfMask(0, 255, 0, 1, gray), &l, &r, &t, &b);
+  PASS(t > 0 && b == 0, "the image mask orientation is correct vertically");
+
+  END_SET("CGContextClipToMask image")
+
+  START_SET("CGContextClipToMask does not affect unmasked contexts")
+
+  unsigned char *buf = calloc(W*W*4, 1);
+  CGContextRef c = CGBitmapContextCreate(buf, W, W, 8, W*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextSetRGBFillColor(c, 0, 1, 0, 1);
+  CGContextFillRect(c, CGRectMake(0, 0, W, W));
+  unsigned char *d = (unsigned char *)CGBitmapContextGetData(c);
+  PASS(A(d,4,4) == 255, "a context with no mask fills normally");
+  CGContextRelease(c); free(buf);
+
+  END_SET("CGContextClipToMask does not affect unmasked contexts")
+
+  CGColorSpaceRelease(dev);
+  return 0;
+}

--- a/Tests/opal/CGClipMask/clipmask.m
+++ b/Tests/opal/CGClipMask/clipmask.m
@@ -9,7 +9,9 @@
 #include <CoreGraphics/CGContext.h>
 #include <CoreGraphics/CGBitmapContext.h>
 #include <CoreGraphics/CGColorSpace.h>
+#include <CoreGraphics/CGColor.h>
 #include <CoreGraphics/CGImage.h>
+#include <CoreGraphics/CGGradient.h>
 #include <CoreGraphics/CGDataProvider.h>
 #include <stdlib.h>
 
@@ -75,6 +77,75 @@ int main(void)
   PASS(t > 0 && b == 0, "the image mask orientation is correct vertically");
 
   END_SET("CGContextClipToMask image")
+
+  START_SET("CGContextClipToMask limits an image")
+
+  /* Left half of the mask paints (black), right half does not. */
+  unsigned char *ib = calloc(W*W*4, 1);
+  CGContextRef ic = CGBitmapContextCreate(ib, W, W, 8, W*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextClipToMask(ic, CGRectMake(0, 0, W, W), halfMask(0, 255, 1, 0, gray));
+  CGContextRef gimgCtx = CGBitmapContextCreate(NULL, W, W, 8, W*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextSetRGBFillColor(gimgCtx, 0, 1, 0, 1);
+  CGContextFillRect(gimgCtx, CGRectMake(0, 0, W, W));
+  CGImageRef gimg = CGBitmapContextCreateImage(gimgCtx);
+  CGContextDrawImage(ic, CGRectMake(0, 0, W, W), gimg);
+  unsigned char *idata = (unsigned char *)CGBitmapContextGetData(ic);
+  PASS(A(idata,2,4) > 0 && A(idata,6,4) == 0, "a drawn image is limited by the mask");
+  CGContextRelease(ic); CGContextRelease(gimgCtx); free(ib);
+
+  END_SET("CGContextClipToMask limits an image")
+
+  START_SET("CGContextClipToMask limits a gradient")
+
+  unsigned char *gb = calloc(W*W*4, 1);
+  CGContextRef gc = CGBitmapContextCreate(gb, W, W, 8, W*4, dev,
+    kCGImageAlphaPremultipliedLast);
+  CGContextClipToMask(gc, CGRectMake(0, 0, W, W), halfMask(0, 255, 1, 0, gray));
+  CGFloat comps[] = {1,0,0,1, 0,0,1,1};
+  CGFloat locs[] = {0, 1};
+  CGGradientRef grad = CGGradientCreateWithColorComponents(dev, comps, locs, 2);
+  CGContextDrawLinearGradient(gc, grad, CGPointMake(0,0), CGPointMake(W,0), 0);
+  unsigned char *gd = (unsigned char *)CGBitmapContextGetData(gc);
+  PASS(A(gd,2,4) > 0 && A(gd,6,4) == 0, "a gradient is limited by the mask");
+  CGContextRelease(gc); free(gb);
+
+  END_SET("CGContextClipToMask limits a gradient")
+
+  START_SET("CGContextClipToMask limits text")
+
+  /* Count painted pixels in the right half with and without a left-half mask;
+     the mask must suppress the right half.  Needs a font. */
+  int rightNoMask = 0, rightMasked = 0, leftMasked = 0;
+  for (int pass = 0; pass < 2; pass++)
+    {
+      unsigned char *tb = calloc(W*W*4, 1);
+      CGContextRef tc = CGBitmapContextCreate(tb, W, W, 8, W*4, dev,
+        kCGImageAlphaPremultipliedLast);
+      if (pass == 1)
+        CGContextClipToMask(tc, CGRectMake(0,0,W,W), halfMask(0,255,1,0,gray));
+      CGContextSelectFont(tc, "DejaVu Sans", 10, kCGEncodingMacRoman);
+      CGContextSetRGBFillColor(tc, 0, 1, 0, 1);
+      CGContextShowTextAtPoint(tc, 0, 2, "MM", 2);
+      unsigned char *td = (unsigned char *)CGBitmapContextGetData(tc);
+      for (int y = 0; y < W; y++)
+        for (int x = 0; x < W; x++)
+          {
+            if (A(td,x,y) > 0)
+              {
+                if (x >= W/2) { if (pass) rightMasked++; else rightNoMask++; }
+                else if (pass) leftMasked++;
+              }
+          }
+      CGContextRelease(tc); free(tb);
+    }
+  if (rightNoMask == 0)
+    SKIP("no font available to draw text")
+  PASS(rightMasked == 0 && leftMasked > 0,
+       "text is limited by the mask (suppressed in the masked-out half)");
+
+  END_SET("CGContextClipToMask limits text")
 
   START_SET("CGContextClipToMask does not affect unmasked contexts")
 


### PR DESCRIPTION
Implements `CGContextClipToMask`, which was a no-op.

Cairo has no persistent alpha clip (unlike a geometric clip path), so the mask is stored on the graphics state and applied per drawing operation: the operation is rendered into a temporary group which is then composited through the mask (`push_group` / draw / `pop_group_to_source` / `mask`).

`CGContextClipToMask` builds an A8 coverage pattern from the mask image, mapped into `rect`. Following CoreGraphics: for an **image mask** a sample of 0 (black) paints fully and 255 (white) not at all; for a **normal image** the alpha channel - or the value, when there is no alpha - is the coverage.

All the drawing operations honour the mask: **fills, strokes, images, gradients and text**. A context with no mask set is unaffected (the masking is guarded), so existing drawing is unchanged.

- The image path pushes its group before its own save/translate and composites after the restore, so the mask is applied in the untranslated user space it was set up in.
- For text the current point is read before the mask is applied, since compositing restores the graphics state.

Verified against Apple CoreGraphics: a half-black/half-white mask clips a green fill to the expected half, for both mask kinds and both orientations (the mask is oriented like an image - its top maps to the top of the rect). Tests also confirm an image, a gradient and text are limited by the mask, and that an unmasked context is unchanged.