### PR TITLE
Fix: report the typographic ascender, not the top of the glyph bounding box

### DIFF
--- a/Source/OpalGraphics/cairo/CairoFontX11.m
+++ b/Source/OpalGraphics/cairo/CairoFontX11.m
@@ -283,7 +283,11 @@ static FcPattern *opal_FcPatternCacheLookup(const char *name)
 - (int) ascent;
 {
   FT_Face ft_face = cairo_ft_scaled_font_lock_face(self->cairofont);
-  int result = ft_face->bbox.yMax;
+  /* The typographic ascender, which is the measure -descent below reports the
+     other half of.  The bounding box top used here before is a different
+     thing: the highest point reached by any glyph in the face, which exceeds
+     the em for many fonts.  -fontBBox already reports that. */
+  int result = ft_face->ascender;
   cairo_ft_scaled_font_unlock_face(self->cairofont);
   return result;
 }


### PR DESCRIPTION
Fix: report the typographic ascender, not the top of the glyph bounding box

-[CairoFontX11 ascent] returned ft_face->bbox.yMax, the top of the box that
encloses every glyph in the face. -descent five lines below returns
-ft_face->descender, the typographic descender, so the two halves of the same
metric pair came from different conventions. The bounding box top is the higher
of the two by however much the tallest accented glyph rises, and for many fonts
it exceeds the em.

The ascent now comes from ft_face->ascender. -fontBBox still reports the
enclosing box and is unchanged.

The caveat is that anything which has been compensating for the larger value
will move. The GNUstep opal backend derives a line height from these two
metrics, so text there sits differently after this change.

Measured through the GNUstep opal backend with DejaVuSans at 12 points: the
ascender goes from 14.79 to 11.14, which is 1901 units of 2048 at 12 points,
and the line height from 17.62 to 13.97. The cairo and xlib backends report 12
and a line height of 14 and 15 for the same font. macOS AppKit reports 9.24 for
Helvetica 12 and 11.60 for its system font at 12, never above the point size.

Tests/gui in libs-gui is 4579 passed and 1 failed on the opal backend either
way; this changes a reported metric rather than a test result.
