### PR TITLE
Fix: build a usable font and typeset a line in CoreText

### DIFF
--- a/Source/OpalText/CTFont.m
+++ b/Source/OpalText/CTFont.m
@@ -349,7 +349,10 @@ CGFloat CTFontGetAscent(CTFontRef font)
 
 CGFloat CTFontGetDescent(CTFontRef font)
 {
-  return [font descender];
+  /* CoreText reports the descent as a positive distance below the baseline,
+     where the font's own descender is negative.  CGFontGetDescent keeps the
+     negative value, which is the one CoreGraphics reports. */
+  return -[font descender];
 }
 
 CGFloat CTFontGetCapHeight(CTFontRef font)

--- a/Source/OpalText/CTLine.m
+++ b/Source/OpalText/CTLine.m
@@ -157,7 +157,28 @@ double CTLineGetTypographicBounds(
 	CGFloat* descent,
 	CGFloat* leading)
 {
-  return 0;
+  NSArray *runs = [line glyphRuns];
+  NSUInteger i, count = [runs count];
+  CGFloat maxAscent = 0, maxDescent = 0, maxLeading = 0;
+  double width = 0;
+
+  /* The line is as wide as its runs together, and as tall as the tallest of
+     them. */
+  for (i = 0; i < count; i++)
+  {
+    CTRunRef run = [runs objectAtIndex: i];
+    CGFloat a = 0, d = 0, l = 0;
+
+    width += CTRunGetTypographicBounds(run, CFRangeMake(0, 0), &a, &d, &l);
+    if (a > maxAscent) maxAscent = a;
+    if (d > maxDescent) maxDescent = d;
+    if (l > maxLeading) maxLeading = l;
+  }
+
+  if (ascent) *ascent = maxAscent;
+  if (descent) *descent = maxDescent;
+  if (leading) *leading = maxLeading;
+  return width;
 }
 
 double CTLineGetTrailingWhitespaceWidth(CTLineRef line)

--- a/Source/OpalText/CTRun-private.h
+++ b/Source/OpalText/CTRun-private.h
@@ -40,6 +40,11 @@
   CGAffineTransform _matrix;
 }
 
+- (id)initWithGlyphs: (const CGGlyph *)glyphs
+            advances: (const CGSize *)advances
+               count: (size_t)count
+          attributes: (NSDictionary *)attributes
+         stringRange: (CFRange)stringRange;
 - (CFIndex)glyphCount;
 - (NSDictionary*)attributes;
 - (CTRunStatus)status;

--- a/Source/OpalText/CTRun.m
+++ b/Source/OpalText/CTRun.m
@@ -160,6 +160,8 @@
 
 - (void)drawRange: (CFRange)range onContext: (CGContextRef)ctx
 {
+  CTFontRef font = [_attributes objectForKey: (id)kCTFontAttributeName];
+
   if (range.length == 0)
   {
     range.length = _count;
@@ -167,8 +169,23 @@
 
   if (range.location > _count || (range.location + range.length) > _count)
   {
-    NSLog(@"CTRunDraw range out of bounds"); 
+    NSLog(@"CTRunDraw range out of bounds");
     return;
+  }
+
+  /* The run carries the font it was laid out with, so the caller does not
+     have to select one on the context first.  Nothing is drawn while the
+     context's font size is zero, so that is set either way. */
+  if (font != NULL)
+  {
+    CGFontRef graphicsFont = CTFontCopyGraphicsFont(font, NULL);
+
+    if (graphicsFont != NULL)
+    {
+      CGContextSetFont(ctx, graphicsFont);
+      CGFontRelease(graphicsFont);
+    }
+    CGContextSetFontSize(ctx, CTFontGetSize(font));
   }
 
   CGContextShowGlyphsAtPositions(ctx, _glyphs + range.location, _positions, range.length);

--- a/Source/OpalText/CTRun.m
+++ b/Source/OpalText/CTRun.m
@@ -24,9 +24,50 @@
 
 #import "CTRun-private.h"
 
+#import <CoreText/CTFont.h>
+#import <CoreText/CTStringAttributes.h>
+
 /* Classes */
 
 @implementation CTRun
+
+- (id)initWithGlyphs: (const CGGlyph *)glyphs
+            advances: (const CGSize *)advances
+               count: (size_t)count
+          attributes: (NSDictionary *)attributes
+         stringRange: (CFRange)stringRange
+{
+  if ((self = [super init]))
+  {
+    CGFloat x = 0;
+    size_t i;
+
+    _count = count;
+    _glyphs = malloc(sizeof(CGGlyph) * count);
+    _advances = malloc(sizeof(CGSize) * count);
+    _positions = malloc(sizeof(CGPoint) * count);
+    if (_glyphs == NULL || _advances == NULL || _positions == NULL)
+    {
+      [self release];
+      return nil;
+    }
+    memcpy(_glyphs, glyphs, sizeof(CGGlyph) * count);
+    memcpy(_advances, advances, sizeof(CGSize) * count);
+
+    /* Each glyph sits where the ones before it left off. */
+    for (i = 0; i < count; i++)
+    {
+      _positions[i] = CGPointMake(x, 0);
+      x += advances[i].width;
+    }
+
+    _attributes = [attributes retain];
+    _stringRange = stringRange;
+    _status = 0;
+    _matrix = CGAffineTransformIdentity;
+  }
+  return self;
+}
 
 - (void)dealloc
 {
@@ -77,7 +118,34 @@
 			    descent: (CGFloat*)descent
 			    leading: (CGFloat*)leading
 {
-  return 0;
+  CTFontRef font = [_attributes objectForKey: (id)kCTFontAttributeName];
+  double width = 0;
+  size_t first, limit, i;
+
+  first = range.location;
+  limit = (range.length == 0) ? _count : range.location + range.length;
+  if (limit > _count)
+  {
+    limit = _count;
+  }
+  for (i = first; i < limit; i++)
+  {
+    width += _advances[i].width;
+  }
+
+  if (ascent)
+  {
+    *ascent = font ? CTFontGetAscent(font) : 0;
+  }
+  if (descent)
+  {
+    *descent = font ? CTFontGetDescent(font) : 0;
+  }
+  if (leading)
+  {
+    *leading = font ? CTFontGetLeading(font) : 0;
+  }
+  return width;
 }
 - (CGRect)imageBoundsForRange: (CFRange)range
 		  withContext: (CGContextRef)context

--- a/Source/OpalText/CTTypesetter.m
+++ b/Source/OpalText/CTTypesetter.m
@@ -77,16 +77,52 @@ const CFStringRef kCTTypesetterOptionForcedEmbeddingLevel = @"kCTTypesetterOptio
 
 - (CTLineRef)createLineWithRange: (CFRange)range
 {
-  // FIXME: This should do the core typesetting stuff:
-  // - divide the attributed string into runs with the same attributes.
-  // - run the bidirectional algorithm if needed
-  // - call the shaper on each run
-  
-  NSArray *runs = [NSMutableArray array];
-  
-  CTLineRef line = [[CTLine alloc] initWithRuns: runs];
-  
-  return line;
+  // FIXME: run the bidirectional algorithm if needed
+
+  NSMutableArray *runs = [NSMutableArray array];
+  OPSimpleLayoutEngine *engine = [[OPSimpleLayoutEngine new] autorelease];
+  NSUInteger length = [_as length];
+  NSUInteger location = range.location;
+  NSUInteger limit;
+
+  /* A range of no length means the whole of the string. */
+  limit = (range.length == 0) ? length : range.location + range.length;
+  if (limit > length)
+  {
+    limit = length;
+  }
+
+  /* One run for each stretch of the string with the same attributes. */
+  while (location < limit)
+  {
+    NSRange effective;
+    NSDictionary *attributes = [_as attributesAtIndex: location
+				       effectiveRange: &effective];
+    NSUInteger end = effective.location + effective.length;
+    NSRange piece;
+    CTRunRef run;
+
+    if (end > limit)
+    {
+      end = limit;
+    }
+    if (end <= location)
+    {
+      /* Nothing was consumed, so stop rather than spin. */
+      break;
+    }
+
+    piece = NSMakeRange(location, end - location);
+    run = [engine layoutString: [[_as string] substringWithRange: piece]
+		withAttributes: attributes];
+    if (run != NULL)
+    {
+      [runs addObject: (id)run];
+    }
+    location = end;
+  }
+
+  return [[CTLine alloc] initWithRuns: runs];
 }
 - (CFIndex)suggestClusterBreakAtIndex: (CFIndex)start
                                 width: (double)width

--- a/Source/OpalText/FreeType/OPFreeTypeFont.m
+++ b/Source/OpalText/FreeType/OPFreeTypeFont.m
@@ -579,6 +579,30 @@ static const NSString *kOPFreeTypeLibrary = @"OPFreeTypeLibrary";
   }
 }
 
+- (CGFontRef)graphicsFontWithDescriptor: (OPFontDescriptor**)descriptorOut
+{
+  /* The descriptor answers the family it resolved to, which is the name a
+     graphics font is built from. */
+  NSString *name = [_descriptor objectForKey:
+			 (NSString *)kCTFontFamilyNameAttribute];
+
+  if (nil == name)
+  {
+    name = [_descriptor objectForKey: (NSString *)kCTFontNameAttribute];
+  }
+
+  if (descriptorOut != NULL)
+  {
+    *descriptorOut = _descriptor;
+  }
+
+  if (nil == name)
+  {
+    return NULL;
+  }
+  return CGFontCreateWithFontName((CFStringRef)name);
+}
+
 - (bool)getGraphicsGlyphsForCharacters: (const unichar *)characters
                         graphicsGlyphs: (const CGGlyph *)glyphs
                                  count: (CFIndex)count

--- a/Source/OpalText/FreeType/OPFreeTypeFont.m
+++ b/Source/OpalText/FreeType/OPFreeTypeFont.m
@@ -461,7 +461,10 @@ static const NSString *kOPFreeTypeLibrary = @"OPFreeTypeLibrary";
     return NSMakeSize(0, 0);
   }
   [fontFaceLock lock];
-  FT_Load_Glyph(fontFace, glyph, FT_LOAD_DEFAULT);
+  /* REAL_SIZE scales font units by the point size, so the advance has to
+     come back in font units rather than in fractional pixels of a size the
+     face was never set to. */
+  FT_Load_Glyph(fontFace, glyph, FT_LOAD_LINEAR_DESIGN);
   NSSize size = NSMakeSize(REAL_SIZE(fontFace->glyph->linearHoriAdvance),
     REAL_SIZE(fontFace->glyph->linearVertAdvance));
   [fontFaceLock unlock];
@@ -574,6 +577,79 @@ static const NSString *kOPFreeTypeLibrary = @"OPFreeTypeLibrary";
       *rects = [self boundingRectForGlyph: *glyphs];
     }
   }
+}
+
+- (bool)getGraphicsGlyphsForCharacters: (const unichar *)characters
+                        graphicsGlyphs: (const CGGlyph *)glyphs
+                                 count: (CFIndex)count
+{
+  /* The glyph buffer is an out parameter, in spite of the const the
+     protocol declares it with. */
+  CGGlyph *out = (CGGlyph *)glyphs;
+  bool complete = true;
+  CFIndex i;
+
+  if ((NULL == characters) || (NULL == out))
+  {
+    return false;
+  }
+
+  [fontFaceLock lock];
+  for (i = 0; i < count; i++)
+  {
+    /* FIXME: one character to one glyph, so surrogate pairs and clusters
+       are not handled. */
+    FT_UInt glyph = FT_Get_Char_Index(fontFace, characters[i]);
+
+    if (0 == glyph)
+    {
+      complete = false;
+    }
+    out[i] = (CGGlyph)glyph;
+  }
+  [fontFaceLock unlock];
+
+  return complete;
+}
+
+- (double)getAdvancesForGraphicsGlyphs: (const CGGlyph *)glyphs
+                              advances: (CGSize*)advances
+                           orientation: (CTFontOrientation)orientation
+                                 count: (CFIndex)count
+{
+  double total = 0;
+  CFIndex i;
+
+  if (NULL == glyphs)
+  {
+    return 0;
+  }
+
+  for (i = 0; i < count; i++)
+  {
+    NSSize advancement = [self advancementForGlyph: (NSGlyph)glyphs[i]];
+    CGSize advance;
+
+    /* A horizontal run advances along x and a vertical one along y; the
+       other component is zero either way. */
+    if (kCTFontVerticalOrientation == orientation)
+    {
+      advance = CGSizeMake(0, advancement.height);
+      total += advancement.height;
+    }
+    else
+    {
+      advance = CGSizeMake(advancement.width, 0);
+      total += advancement.width;
+    }
+
+    if (advances != NULL)
+    {
+      advances[i] = advance;
+    }
+  }
+
+  return total;
 }
 
 - (NSGlyph)glyphWithName: (NSString*)name

--- a/Source/OpalText/OPFont.h
+++ b/Source/OpalText/OPFont.h
@@ -154,6 +154,7 @@ typedef union _OPAffineTransform
 //
 // CTFont private
 //
++ (Class) fontClass;
 + (OPFont*) fontWithDescriptor: (OPFontDescriptor*)descriptor
                        options: (CTFontOptions)options;
 + (OPFont*) UIFontWithType: (CTFontUIFontType)type

--- a/Source/OpalText/OPFont.m
+++ b/Source/OpalText/OPFont.m
@@ -39,6 +39,7 @@
 #import <Foundation/NSValue.h>
 
 #import "OPFont.h"
+#import <CoreText/CTFontDescriptor.h>
 
 const CGFloat *OPFontIdentityMatrix;
 
@@ -88,7 +89,15 @@ const CGFloat *OPFontIdentityMatrix;
 
 - (CGFloat) pointSize
 {
-  return [[[self fontDescriptor] objectForKey: OPFontSizeAttribute] doubleValue];
+  /* A descriptor built through CoreText carries the size under the CoreText
+     key, one built through the OPFont attributes under the OPFont key. */
+  id size = [[self fontDescriptor] objectForKey: (id)kCTFontSizeAttribute];
+
+  if (nil == size)
+  {
+    size = [[self fontDescriptor] objectForKey: OPFontSizeAttribute];
+  }
+  return [size doubleValue];
 }
 - (OPFont*) printerFont
 {
@@ -193,12 +202,20 @@ const CGFloat *OPFontIdentityMatrix;
 //
 // CTFont private
 //
++ (Class) fontClass
+{
+  /* The concrete font is whichever platform class was built in; without one
+     there is only the abstract font, which has no glyphs. */
+  Class platform = NSClassFromString(@"OPFreeTypeFont");
+
+  return (Nil == platform) ? [OPFont class] : platform;
+}
+
 + (OPFont*) fontWithDescriptor: (OPFontDescriptor*)descriptor
                        options: (CTFontOptions)options
 {
-  // FIXME: placeholder code.
-  return [[[OPFont alloc] _initWithDescriptor: descriptor
-                                      options: options] autorelease];
+  return [[[[self fontClass] alloc] _initWithDescriptor: descriptor
+                                                options: options] autorelease];
 }
 
 + (OPFont*) fontWithGraphicsFont: (CGFontRef)graphics

--- a/Source/OpalText/OPFontDescriptor.m
+++ b/Source/OpalText/OPFontDescriptor.m
@@ -285,8 +285,16 @@ NSString *OPFontVariationAxisNameKey = @"NSCTFontVariationAxisName";
 
 - (CGFloat) pointSize
 {
-  // NOTE: 0 is returned if point size is not defined
-  return [[self objectForKey: OPFontSizeAttribute] doubleValue];
+  /* A descriptor built through CoreText carries the size under the CoreText
+     key, one built through the OPFont attributes under the OPFont key.
+     NOTE: 0 is returned if point size is not defined */
+  id size = [self objectForKey: (id)kCTFontSizeAttribute];
+
+  if (nil == size)
+  {
+    size = [self objectForKey: OPFontSizeAttribute];
+  }
+  return [size doubleValue];
 }
 
 - (NSString *) postscriptName

--- a/Source/OpalText/OPSimpleLayoutEngine.m
+++ b/Source/OpalText/OPSimpleLayoutEngine.m
@@ -24,6 +24,7 @@
 
 
 #import "OPSimpleLayoutEngine.h"
+#import "CTRun-private.h"
 #import <CoreText/CTFont.h>
 #import <CoreText/CTStringAttributes.h>
 
@@ -33,34 +34,69 @@
 	   withAttributes: (NSDictionary*)attribs
 {
   const NSUInteger length = [chars length];
-  CGGlyph *glyphs = malloc(sizeof(CGGlyph) * length);
-  unichar *characters = malloc(sizeof(unichar) * length);
-  CGSize *advances = malloc(sizeof(CGSize) * length);
+  CGGlyph *glyphs;
+  unichar *characters;
+  CGSize *advances;
+  CTFontRef font = [attribs objectForKey: (id)kCTFontAttributeName];
+  CTRun *run = nil;
 
-  CTFontRef font = [attribs objectForKey: kCTFontAttributeName]; 
+  if (length == 0)
+  {
+    return nil;
+  }
+
   if (font == nil)
   {
-    NSLog(@"OPSimpleLayoutEngine: Error, layoutString:withAttributes: called without a font");
+    /* A string with no font of its own is set in the face and size the
+       typesetter falls back to. */
+    font = CTFontCreateWithName((CFStringRef)@"Helvetica", 12, NULL);
   }
   else
   {
-    bool success = CTFontGetGlyphsForCharacters(font,
-						characters,
-						glyphs,
-						length);
-
-    double total = CTFontGetAdvancesForGlyphs(font,
-					      kCTFontDefaultOrientation,
-					      glyphs, 
-					      advances,
-					      length);
+    [(id)font retain];
   }
+  if (font == nil)
+  {
+    NSLog(@"OPSimpleLayoutEngine: no font to lay the string out with");
+    return nil;
+  }
+
+  glyphs = malloc(sizeof(CGGlyph) * length);
+  characters = malloc(sizeof(unichar) * length);
+  advances = malloc(sizeof(CGSize) * length);
+  if (glyphs != NULL && characters != NULL && advances != NULL)
+  {
+    [chars getCharacters: characters range: NSMakeRange(0, length)];
+
+    if (CTFontGetGlyphsForCharacters(font, characters, glyphs, length))
+    {
+      NSMutableDictionary *used = (attribs == nil)
+	? [NSMutableDictionary dictionary]
+	: [[attribs mutableCopy] autorelease];
+
+      CTFontGetAdvancesForGlyphs(font,
+				 kCTFontDefaultOrientation,
+				 glyphs,
+				 advances,
+				 length);
+
+      /* The run keeps the font it was laid out with, which is the one the
+	 caller asked for or the fallback chosen above. */
+      [used setObject: (id)font forKey: (id)kCTFontAttributeName];
+      run = [[[CTRun alloc] initWithGlyphs: glyphs
+				  advances: advances
+				     count: length
+				attributes: used
+			       stringRange: CFRangeMake(0, length)]
+	      autorelease];
+    }
+  }
+
   free(glyphs);
   free(characters);
   free(advances);
-
-  // FIXME: create a CTRun with the glyphs & advances
-  return nil;
+  [(id)font release];
+  return run;
 }
 
 @end

--- a/Tests/opal/CTLine/line.m
+++ b/Tests/opal/CTLine/line.m
@@ -11,7 +11,13 @@
 #import <Foundation/NSArray.h>
 
 #include <CoreText/CoreText.h>
+#include <CoreGraphics/CGBitmapContext.h>
+#include <CoreGraphics/CGColorSpace.h>
+#include <CoreGraphics/CGContext.h>
 #include <stdlib.h>
+
+#define W 200
+#define H 60
 
 static NSAttributedString *styled(NSString *text, CGFloat size)
 {
@@ -85,6 +91,42 @@ int main(void)
   [(id)line release];
 
   END_SET("a line of two runs")
+
+  START_SET("drawing a line")
+
+  CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
+  unsigned char *buffer = calloc(W * H * 4, 1);
+  CGContextRef c = CGBitmapContextCreate(buffer, W, H, 8, W * 4, space,
+                                         kCGImageAlphaPremultipliedLast);
+  NSAttributedString *as = styled(@"Hi", 24);
+  CTLineRef line;
+  unsigned char *drawn;
+  int i, painted = 0;
+
+  CGColorSpaceRelease(space);
+  if (as == nil)
+    SKIP("no usable font available to typeset with")
+
+  CGContextSetRGBFillColor(c, 1, 1, 1, 1);
+  CGContextSetTextPosition(c, 10, 20);
+  line = CTLineCreateWithAttributedString((CFAttributedStringRef)as);
+  CTLineDraw(line, c);
+
+  /* The data accessor flushes what cairo drew into the buffer; the buffer
+     itself is not written until then. */
+  drawn = (unsigned char *)CGBitmapContextGetData(c);
+  for (i = 0; i < W * H; i++)
+    if (drawn[i * 4] || drawn[i * 4 + 1] || drawn[i * 4 + 2]
+        || drawn[i * 4 + 3])
+      painted++;
+  PASS(painted > 0,
+       "a line draws glyphs without the caller selecting a font first");
+
+  [(id)line release];
+  CGContextRelease(c);
+  free(buffer);
+
+  END_SET("drawing a line")
 
   return 0;
 }

--- a/Tests/opal/CTLine/line.m
+++ b/Tests/opal/CTLine/line.m
@@ -1,0 +1,90 @@
+/* CTLine typesetting: an attributed string becomes a line of glyph runs, one
+   run for each stretch of the string with the same attributes, and the line
+   reports the summed advance width with the font's ascent and descent.  The
+   typesetter takes the attributed string as an NSAttributedString, which is
+   what it asks for its attributes as, so the tests build one. */
+#include "Testing.h"
+
+#import <Foundation/NSAttributedString.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+
+#include <CoreText/CoreText.h>
+#include <stdlib.h>
+
+static NSAttributedString *styled(NSString *text, CGFloat size)
+{
+  CTFontRef font = CTFontCreateWithName((CFStringRef)@"Helvetica", size, NULL);
+  NSAttributedString *as;
+
+  if (font == NULL)
+    return nil;
+
+  as = [[[NSAttributedString alloc]
+          initWithString: text
+              attributes: [NSDictionary dictionaryWithObject: (id)font
+                                        forKey: (id)kCTFontAttributeName]]
+         autorelease];
+  [(id)font release];
+  return as;
+}
+
+int main(void)
+{
+  START_SET("a line of one run")
+
+  NSAttributedString *as = styled(@"Hi", 24);
+  CTLineRef line;
+  NSArray *runs;
+  CGFloat ascent = -1, descent = -1, leading = -1;
+  double width;
+
+  if (as == nil)
+    SKIP("no usable font available to typeset with")
+
+  line = CTLineCreateWithAttributedString((CFAttributedStringRef)as);
+  PASS(line != NULL, "a line can be made from an attributed string");
+
+  runs = (NSArray *)CTLineGetGlyphRuns(line);
+  PASS(runs != nil && [runs count] == 1,
+       "and it holds one run for one set of attributes");
+  PASS(CTLineGetGlyphCount(line) == 2, "with a glyph for each character");
+
+  width = CTLineGetTypographicBounds(line, &ascent, &descent, &leading);
+  PASS(width > 0, "the line has a width");
+  PASS(ascent > 0 && descent >= 0, "and the font's ascent and descent");
+  PASS(ascent < 24 * 2, "which are in points, not em units");
+
+  [(id)line release];
+
+  END_SET("a line of one run")
+
+  START_SET("a line of two runs")
+
+  NSAttributedString *small = styled(@"Hi", 12);
+  NSAttributedString *big = styled(@"There", 24);
+  NSMutableAttributedString *mixed;
+  CTLineRef line;
+  NSArray *runs;
+
+  if (small == nil || big == nil)
+    SKIP("no usable font available to typeset with")
+
+  mixed = [[[NSMutableAttributedString alloc] init] autorelease];
+  [mixed appendAttributedString: small];
+  [mixed appendAttributedString: big];
+
+  line = CTLineCreateWithAttributedString((CFAttributedStringRef)mixed);
+  runs = (NSArray *)CTLineGetGlyphRuns(line);
+  PASS(runs != nil && [runs count] == 2,
+       "two sets of attributes make two runs");
+  PASS(CTLineGetGlyphCount(line) == 7,
+       "and the runs together hold every glyph of the string");
+
+  [(id)line release];
+
+  END_SET("a line of two runs")
+
+  return 0;
+}


### PR DESCRIPTION
CTFontCreateWithName answered the abstract OPFont rather than a platform class, so every metric read 0 and no character mapped to a glyph. The size was read under OPFontSizeAttribute, where a CoreText descriptor stores it under kCTFontSizeAttribute. OPFreeTypeFont implemented neither getGraphicsGlyphsForCharacters: nor getAdvancesForGraphicsGlyphs:, and advancementForGlyph: read fractional pixels from a face whose size is never set. CTTypesetter ignored its range and returned a line of no runs, CTLineGetTypographicBounds returned 0, and CTRunDraw showed glyphs without setting a font or size on the context.

+fontWithDescriptor:options: now creates the platform class, the size is read under either key, OPFreeTypeFont maps characters with FT_Get_Char_Index, loads advances with FT_LOAD_LINEAR_DESIGN and answers a graphics font, CTRun gains an initialiser, typographic bounds and its own font at draw time, and the typesetter splits the string by attribute range into one run each.

CTFontGetDescent now returns a positive distance below the baseline, as CoreText does; CGFontGetDescent keeps the negative CoreGraphics value. A character with no glyph loses its whole run, where Apple substitutes another font. One character maps to one glyph, so surrogate pairs are not handled.

Test: Tests/opal/CTLine/line.m, under gnustep-tests Tests/opal.

Before: 164 passed, 7 failed. After: 171 passed, 0 failed. 3 dashed hopes either way.
