### PR TITLE
Feature: truncate a CTLine to a width

### DIFF
--- a/Source/OpalText/CTLine.m
+++ b/Source/OpalText/CTLine.m
@@ -23,6 +23,7 @@
    */
 
 #import "CTLine-private.h"
+#import "CTRun-private.h"
 
 /* Classes */
 
@@ -32,7 +33,24 @@
 {
   if ((self = [super init]))
   {
+    const NSUInteger count = [runs count];
+    CGFloat x = 0;
+    NSUInteger i;
+
     _runs = [runs retain];
+
+    /* A run's positions are relative to the origin of the line holding it, so
+       each run is laid out where the one before it ended. */
+    for (i = 0; i < count; i++)
+    {
+      CTRun *run = [runs objectAtIndex: i];
+
+      [run placeAtX: x];
+      x += [run typographicBoundsForRange: CFRangeMake(0, 0)
+                                   ascent: NULL
+                                  descent: NULL
+                                  leading: NULL];
+    }
   }
   return self;
 }
@@ -69,11 +87,199 @@
   return _runs;
 }
 
+/* The advance width of every glyph in the line, in order.  The caller frees
+   the array. */
+- (CGFloat *)glyphWidthsCount: (CFIndex *)countOut
+{
+  const NSUInteger runsCount = [_runs count];
+  CFIndex total = [self glyphCount];
+  CGFloat *widths;
+  CFIndex at = 0;
+  NSUInteger i;
+
+  *countOut = total;
+  if (total == 0)
+  {
+    return NULL;
+  }
+
+  widths = malloc(sizeof(CGFloat) * total);
+  if (widths == NULL)
+  {
+    return NULL;
+  }
+
+  for (i = 0; i < runsCount; i++)
+  {
+    CTRun *run = [_runs objectAtIndex: i];
+    const CGSize *advances = [run advances];
+    CFIndex j, count = [run glyphCount];
+
+    for (j = 0; j < count && at < total; j++)
+    {
+      widths[at++] = advances[j].width;
+    }
+  }
+  return widths;
+}
+
+/* How many glyphs fit in room, counted from the start of the line or from its
+   end.  A glyph fits when the glyphs up to and including it are no wider than
+   room. */
+static CFIndex
+OPGlyphsFitting(const CGFloat *widths, CFIndex count, double room, BOOL fromEnd)
+{
+  double used = 0;
+  CFIndex kept = 0, i;
+
+  for (i = 0; i < count; i++)
+  {
+    CGFloat advance = widths[fromEnd ? count - 1 - i : i];
+
+    if (used + advance > room)
+    {
+      break;
+    }
+    used += advance;
+    kept++;
+  }
+  return kept;
+}
+
+/* The runs covering count glyphs of this line from index, trimming the runs
+   at either end where the range falls inside one. */
+- (NSArray *)runsForGlyphsFrom: (CFIndex)index count: (CFIndex)count
+{
+  NSMutableArray *kept = [NSMutableArray array];
+  const NSUInteger runsCount = [_runs count];
+  CFIndex at = 0;
+  NSUInteger i;
+
+  for (i = 0; i < runsCount && count > 0; i++)
+  {
+    CTRun *run = [_runs objectAtIndex: i];
+    CFIndex glyphs = [run glyphCount];
+    CFIndex first, take;
+
+    if (at + glyphs <= index)
+    {
+      at += glyphs;
+      continue;
+    }
+
+    first = (index > at) ? index - at : 0;
+    take = glyphs - first;
+    if (take > count)
+    {
+      take = count;
+    }
+    if (take > 0)
+    {
+      CTRun *piece = [run runWithGlyphsFrom: first count: take];
+
+      if (piece != nil)
+      {
+        [kept addObject: piece];
+      }
+      count -= take;
+    }
+    at += glyphs;
+  }
+  return kept;
+}
+
 - (CTLine*) truncatedLineWithWidth: (double)width
                     truncationType: (CTLineTruncationType)truncationType
                    truncationToken:	(CTLineRef)truncationToken
 {
-  return nil;
+  CFIndex total = 0;
+  CGFloat *widths = [self glyphWidthsCount: &total];
+  NSMutableArray *runs;
+  double whole = 0, tokenWidth = 0, room;
+  CFIndex head = 0, tail = 0, i;
+
+  if (widths == NULL)
+  {
+    return self;
+  }
+  for (i = 0; i < total; i++)
+  {
+    whole += widths[i];
+  }
+
+  /* A line that already fits is answered as it stands, which is what Apple
+     answers. */
+  if (whole <= width)
+  {
+    free(widths);
+    return self;
+  }
+
+  if (truncationToken != NULL)
+  {
+    tokenWidth = CTLineGetTypographicBounds(truncationToken, NULL, NULL, NULL);
+  }
+
+  /* Nothing can be drawn where even the token does not fit. */
+  room = width - tokenWidth;
+  if (room < 0)
+  {
+    free(widths);
+    return nil;
+  }
+
+  switch (truncationType)
+  {
+    case kCTLineTruncationStart:
+      tail = OPGlyphsFitting(widths, total, room, YES);
+      break;
+
+    case kCTLineTruncationMiddle:
+      head = OPGlyphsFitting(widths, total, room / 2.0, NO);
+      tail = OPGlyphsFitting(widths, total, room / 2.0, YES);
+      if (head + tail > total)
+      {
+        tail = total - head;
+      }
+      break;
+
+    case kCTLineTruncationEnd:
+    default:
+      head = OPGlyphsFitting(widths, total, room, NO);
+      break;
+  }
+  free(widths);
+
+  runs = [NSMutableArray array];
+  if (head > 0)
+  {
+    [runs addObjectsFromArray: [self runsForGlyphsFrom: 0 count: head]];
+  }
+  if (truncationToken != NULL)
+  {
+    /* The token's own runs belong to the token's line, which keeps them, so
+       the truncated line takes copies to lay out for itself. */
+    NSArray *tokenRuns = [(CTLine *)truncationToken glyphRuns];
+    NSUInteger j;
+
+    for (j = 0; j < [tokenRuns count]; j++)
+    {
+      CTRun *run = [tokenRuns objectAtIndex: j];
+      CTRun *copy = [run runWithGlyphsFrom: 0 count: [run glyphCount]];
+
+      if (copy != nil)
+      {
+        [runs addObject: copy];
+      }
+    }
+  }
+  if (tail > 0)
+  {
+    [runs addObjectsFromArray: [self runsForGlyphsFrom: total - tail
+                                                 count: tail]];
+  }
+
+  return [[[CTLine alloc] initWithRuns: runs] autorelease];
 }
 
 - (double)penOffset

--- a/Source/OpalText/CTRun-private.h
+++ b/Source/OpalText/CTRun-private.h
@@ -62,4 +62,16 @@
 - (CGAffineTransform)matrix;
 - (void)drawRange: (CFRange)range onContext: (CGContextRef)ctx;
 
+/**
+ * Lays the run's glyphs out from x, keeping their advances.  A run's positions
+ * are relative to the origin of the line holding it, so a line places each of
+ * its runs after the one before it.
+ */
+- (void)placeAtX: (CGFloat)x;
+
+/**
+ * A run holding count glyphs of this one, starting at index.
+ */
+- (CTRun *)runWithGlyphsFrom: (CFIndex)index count: (CFIndex)count;
+
 @end

--- a/Source/OpalText/CTRun.m
+++ b/Source/OpalText/CTRun.m
@@ -158,6 +158,33 @@
   return _matrix;
 }
 
+- (void)placeAtX: (CGFloat)x
+{
+  size_t i;
+
+  for (i = 0; i < _count; i++)
+  {
+    _positions[i] = CGPointMake(x, 0);
+    x += _advances[i].width;
+  }
+}
+
+- (CTRun *)runWithGlyphsFrom: (CFIndex)index count: (CFIndex)count
+{
+  if (index < 0 || count < 0 || (size_t)(index + count) > _count)
+  {
+    return nil;
+  }
+
+  return [[[CTRun alloc] initWithGlyphs: _glyphs + index
+                               advances: _advances + index
+                                  count: count
+                             attributes: _attributes
+                            stringRange:
+                              CFRangeMake(_stringRange.location + index,
+                                          count)] autorelease];
+}
+
 - (void)drawRange: (CFRange)range onContext: (CGContextRef)ctx
 {
   CTFontRef font = [_attributes objectForKey: (id)kCTFontAttributeName];

--- a/Tests/opal/CTLine/truncation.m
+++ b/Tests/opal/CTLine/truncation.m
@@ -1,0 +1,171 @@
+/* CTLineCreateTruncatedLine: a line too wide for the space it is given is cut
+   down to fit, with a token standing in for what was dropped.
+
+   The rules were measured against Apple CoreText with Helvetica 24, a line of
+   16 H and an ellipsis token: a line that already fits comes back as it went
+   in; the token is kept and glyphs are dropped until the rest fits; a width
+   narrower than the token alone answers nothing; and the truncated line is no
+   wider than the width asked for.  Glyph advances differ between rasterisers,
+   so the counts here are relative to the line's own metrics. */
+#include "Testing.h"
+
+#import <Foundation/NSAttributedString.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+
+#include <CoreText/CoreText.h>
+#include <stdlib.h>
+
+static NSAttributedString *styled(NSString *text, CGFloat size)
+{
+  CTFontRef font = CTFontCreateWithName((CFStringRef)@"Helvetica", size, NULL);
+  NSAttributedString *as;
+
+  if (font == NULL)
+    return nil;
+
+  as = [[[NSAttributedString alloc]
+          initWithString: text
+              attributes: [NSDictionary dictionaryWithObject: (id)font
+                                        forKey: (id)kCTFontAttributeName]]
+         autorelease];
+  [(id)font release];
+  return as;
+}
+
+static CTLineRef lineOf(NSString *text)
+{
+  NSAttributedString *as = styled(text, 24);
+
+  if (as == nil)
+    return NULL;
+  return CTLineCreateWithAttributedString((CFAttributedStringRef)as);
+}
+
+int main(void)
+{
+  START_SET("truncating a line")
+
+  CTLineRef full = lineOf(@"HHHHHHHHHHHHHHHH");
+  CTLineRef token;
+  double whole, tokenWidth;
+
+  if (full == NULL || CTLineGetGlyphCount(full) == 0)
+    SKIP("this build's CoreText typesets no runs")
+
+  token = lineOf(@"...");
+  whole = CTLineGetTypographicBounds(full, NULL, NULL, NULL);
+  tokenWidth = CTLineGetTypographicBounds(token, NULL, NULL, NULL);
+  PASS(whole > 0 && tokenWidth > 0, "the line and the token have a width");
+
+  {
+    CTLineRef fits = CTLineCreateTruncatedLine(full, whole + 50,
+                                               kCTLineTruncationEnd, token);
+
+    PASS(fits == full, "a line that already fits is answered as it stands");
+    [(id)fits release];
+  }
+
+  {
+    CTLineRef cut = CTLineCreateTruncatedLine(full, whole / 2,
+                                              kCTLineTruncationEnd, token);
+
+    PASS(cut != NULL, "a line too wide for the width is truncated");
+    PASS(CTLineGetGlyphCount(cut) < CTLineGetGlyphCount(full),
+         "with fewer glyphs than it had");
+    PASS(CTLineGetTypographicBounds(cut, NULL, NULL, NULL) <= whole / 2,
+         "and no wider than the width it was given");
+    PASS([(NSArray *)CTLineGetGlyphRuns(cut) count] == 2,
+         "in a run of what was kept and a run of the token");
+    [(id)cut release];
+  }
+
+  {
+    CTLineRef cut = CTLineCreateTruncatedLine(full, whole / 2,
+                                              kCTLineTruncationEnd, NULL);
+
+    PASS(cut != NULL && [(NSArray *)CTLineGetGlyphRuns(cut) count] == 1,
+         "with no token there is nothing but what was kept");
+    PASS(CTLineGetTypographicBounds(cut, NULL, NULL, NULL) <= whole / 2,
+         "and it fits the width as well");
+    [(id)cut release];
+  }
+
+  {
+    CTLineRef start = CTLineCreateTruncatedLine(full, whole / 2,
+                                                kCTLineTruncationStart, token);
+    CTLineRef middle = CTLineCreateTruncatedLine(full, whole / 2,
+                                                 kCTLineTruncationMiddle,
+                                                 token);
+
+    PASS(start != NULL && [(NSArray *)CTLineGetGlyphRuns(start) count] == 2,
+         "truncating at the start puts the token before what was kept");
+    PASS(middle != NULL && [(NSArray *)CTLineGetGlyphRuns(middle) count] == 3,
+         "and in the middle it goes between the two ends that were kept");
+    PASS(CTLineGetTypographicBounds(start, NULL, NULL, NULL) <= whole / 2
+         && CTLineGetTypographicBounds(middle, NULL, NULL, NULL) <= whole / 2,
+         "both fitting the width");
+    [(id)start release];
+    [(id)middle release];
+  }
+
+  {
+    CTLineRef none = CTLineCreateTruncatedLine(full, tokenWidth / 2,
+                                               kCTLineTruncationEnd, token);
+    CTLineRef zero = CTLineCreateTruncatedLine(full, 0,
+                                               kCTLineTruncationEnd, token);
+    CTLineRef negative = CTLineCreateTruncatedLine(full, -10,
+                                                   kCTLineTruncationEnd,
+                                                   token);
+
+    PASS(none == NULL, "a width narrower than the token answers nothing");
+    PASS(zero == NULL, "and so does a width of nothing");
+    PASS(negative == NULL, "and a width below nothing");
+  }
+
+  {
+    /* Room for the token and not one glyph more. */
+    CTLineRef only = CTLineCreateTruncatedLine(full, tokenWidth,
+                                               kCTLineTruncationEnd, token);
+
+    PASS(only != NULL && CTLineGetGlyphCount(only)
+                           == CTLineGetGlyphCount(token),
+         "a width holding the token alone answers the token alone");
+    [(id)only release];
+  }
+
+  /* The runs of a line are laid out one after another, so a truncated line
+     draws its token where the glyphs it kept end. */
+  {
+    CTLineRef cut = CTLineCreateTruncatedLine(full, whole / 2,
+                                              kCTLineTruncationEnd, token);
+    NSArray *runs = (NSArray *)CTLineGetGlyphRuns(cut);
+
+    if ([runs count] < 2)
+      {
+        PASS(NO, "a truncated line holds the glyphs kept and the token");
+      }
+    else
+      {
+        CTRunRef kept = [runs objectAtIndex: 0];
+        CTRunRef tokenRun = [runs objectAtIndex: 1];
+        CGPoint keptStart = CTRunGetPositionsPtr(kept)[0];
+        CGPoint tokenStart = CTRunGetPositionsPtr(tokenRun)[0];
+        double keptWidth = CTRunGetTypographicBounds(kept, CFRangeMake(0, 0),
+                                                     NULL, NULL, NULL);
+
+        PASS(keptStart.x == 0, "the first run of a line starts at its origin");
+        PASS(tokenStart.x == keptWidth,
+             "and the token starts where that run ended");
+      }
+    [(id)cut release];
+  }
+
+  [(id)token release];
+  [(id)full release];
+
+  END_SET("truncating a line")
+
+  return 0;
+}


### PR DESCRIPTION
-[CTLine truncatedLineWithWidth:truncationType:truncationToken:] returns nil, so CTLineCreateTruncatedLine answers nothing and a line cannot be cut to a width. Separately, every run of a line was laid out from x 0, so a line of more than one run drew all of its runs at the same place.

A line now keeps the glyphs that fit in the width less the width of the token, from the start for kCTLineTruncationEnd, from the end for kCTLineTruncationStart, and from both ends for kCTLineTruncationMiddle, and builds a line from those runs with a copy of the token between or after them. CTRun gained -placeAtX: and -runWithGlyphsFrom:count:, and a line lays each of its runs out where the one before it ended, which is what a run's positions are relative to on Apple.

Checked against Apple CoreText: a line that already fits is answered as it stands, a width narrower than the token alone answers NULL, a width holding only the token answers the token, and the result is never wider than the width given.

Tests: Tests/opal/CTLine/truncation.m.

Before: 189 passed, 0 failed. After: 206 passed, 0 failed. 5 dashed hopes either way. Without the change 8 of the new assertions fail.
