### PR TITLE
Fix: correct the copyright and author of two new headers

### DIFF
--- a/Source/OpalGraphics/CGFunction-private.h
+++ b/Source/OpalGraphics/CGFunction-private.h
@@ -2,10 +2,10 @@
 
  <abstract>C Interface to graphics drawing library</abstract>
 
- Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+ Copyright <copy>(C) 2026 Free Software Foundation, Inc.</copy>
 
- Author: Eric Wasylishen
- Date: June 2010
+ Author: Todd White <todd.white@thalion.global>
+ Date: July 2026
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/Source/OpalGraphics/CGShading-private.h
+++ b/Source/OpalGraphics/CGShading-private.h
@@ -2,10 +2,10 @@
 
  <abstract>C Interface to graphics drawing library</abstract>
 
- Copyright <copy>(C) 2010 Free Software Foundation, Inc.</copy>
+ Copyright <copy>(C) 2026 Free Software Foundation, Inc.</copy>
 
- Author: Eric Wasylishen
- Date: June 2010
+ Author: Todd White <todd.white@thalion.global>
+ Date: July 2026
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
CGFunction-private.h and CGShading-private.h were added in #37 and carry the header of the file they were modelled on: copyright 2010, with Eric Wasylishen as the author. Both files are new and everything they declare came with them, so the header names the wrong person and the wrong year.

The three files @fredkiefer  marked in #48 are corrected on that branch. Checking every file added by this work across the repository, in merged commits and on open branches, those five are all of them.

Comments only, no code, so there is nothing for the tests to show either way.
