### PR TITLE
Fix: composite a transparency layer using the context shadow

### DIFF
--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -45,7 +45,7 @@ extern CGRect opal_CGImageGetSourceRect(CGImageRef image);
 
 static inline void set_color(cairo_pattern_t **cp, CGColorRef clr, double alpha);
 static void start_shadow(CGContextRef ctx);
-static void end_shadow(CGContextRef ctx, CGRect bounds);
+static void end_shadow(CGContextRef ctx);
 
 
 @implementation CGContext
@@ -338,6 +338,8 @@ void CGContextSaveGState(CGContextRef ctx)
   cairo_pattern_reference(ctadd->fill_cp);
   CGColorRetain(ctadd->stroke_color);
   cairo_pattern_reference(ctadd->stroke_cp);
+  CGColorRetain(ctadd->shadow_color);
+  cairo_pattern_reference(ctadd->shadow_cp);
   ctadd->next = ctx->add;
   ctx->add = ctadd;
   OPRESTORELOGGING()
@@ -362,6 +364,8 @@ void CGContextRestoreGState(CGContextRef ctx)
   cairo_pattern_destroy(ctx->add->fill_cp);
   CGColorRelease(ctx->add->stroke_color);
   cairo_pattern_destroy(ctx->add->stroke_cp);
+  CGColorRelease(ctx->add->shadow_color);
+  cairo_pattern_destroy(ctx->add->shadow_cp);
   ctadd = ctx->add->next;
   free(ctx->add);
   ctx->add = ctadd;
@@ -586,7 +590,7 @@ void CGContextSetShadow(
 {  
   OPLOGCALL("ctx /*%p*/, CGSizeMake(%g, %g), %g", ctx, offset.width, offset.height,
             radius)
-  CGColorRef defaultShadowColor = CGColorCreateGenericGray(0, 0.3);
+  CGColorRef defaultShadowColor = CGColorCreateGenericGray(0, 1.0 / 3.0);
   CGContextSetShadowWithColor(ctx, offset, radius, defaultShadowColor);
   CGColorRelease(defaultShadowColor);
   OPRESTORELOGGING()
@@ -603,10 +607,19 @@ void CGContextSetShadowWithColor(
   CGColorRelease(ctx->add->shadow_color);
   ctx->add->shadow_color = color;
   CGColorRetain(color);
-  
+
   ctx->add->shadow_offset = offset;
   ctx->add->shadow_radius = radius;
-  set_color(&ctx->add->shadow_cp, color, 1.0);
+  if (color)
+    {
+      set_color(&ctx->add->shadow_cp, color, 1.0);
+    }
+  else
+    {
+      /* A NULL color turns the shadow off. */
+      cairo_pattern_destroy(ctx->add->shadow_cp);
+      ctx->add->shadow_cp = NULL;
+    }
   OPRESTORELOGGING()
 }
 
@@ -848,7 +861,7 @@ void CGContextStrokePath(CGContextRef ctx)
   cairo_stroke(ctx->ct);
   
   if (ctx->add->shadow_cp) {
-    end_shadow(ctx, CGRectMake(0,0,500,500)); //FIXME
+    end_shadow(ctx);
   }
   
   cret = cairo_status(ctx->ct);
@@ -889,7 +902,7 @@ static void fill_path(CGContextRef ctx, int eorule, int preserve)
   if (!preserve) cairo_new_path(ctx->ct);
   
   if (ctx->add->shadow_cp) {
-    end_shadow(ctx, CGRectMake(0,0,500,500)); //FIXME
+    end_shadow(ctx);
   }
   
   cret = cairo_status(ctx->ct);
@@ -2126,7 +2139,7 @@ static inline void blur_1D(unsigned char *input, unsigned char *output,
     sum += input[stride * MAX(0,MIN(width-1,i))];
   }
   for (i = 0; i < width; i++) {
-    output[stride * i] = (sum / ((2*radius) + 1));
+    output[stride * i] = (sum + radius) / ((2*radius) + 1);
     sum += input[stride * MAX(0,MIN(width-1, i+1+radius))];
     sum -= input[stride * MAX(0,MIN(width-1, i-radius))];
   }
@@ -2140,24 +2153,39 @@ static void blur_alpha_image_surface(cairo_surface_t *surface, float radius)
   int stride = cairo_image_surface_get_stride(surface);
   int intRadius = (int)radius;
   unsigned char *data = cairo_image_surface_get_data(surface);
-  unsigned char *buf = malloc(stride * imageHeight);
+  unsigned char *buf;
+  /* Three box blurs stand in for a Gaussian.  Each spreads an edge by its
+     own radius, so the three radii add up to the one that was asked for. */
+  int radii[3];
 
   if (intRadius < 1)
     return;
 
   if (cairo_image_surface_get_format(surface) != CAIRO_FORMAT_A8)
     return;
- 
+
+  radii[0] = (intRadius + 2) / 3;
+  radii[1] = (intRadius + 1) / 3;
+  radii[2] = intRadius / 3;
+
+  buf = malloc(stride * imageHeight);
+  if (!buf)
+    return;
+
   for (iteration = 0; iteration < 3; iteration++)
     {
+      if (radii[iteration] < 1)
+        continue;
+
       // Horizontal blur
       for (y = 0; y < imageHeight; y++)
-        blur_1D(data + (y*stride), buf + (y*stride), 1, imageWidth, intRadius);
+        blur_1D(data + (y*stride), buf + (y*stride), 1, imageWidth,
+                radii[iteration]);
       memcpy(data, buf, stride*imageHeight);
 
       // Vertical blur
       for (x = 0; x < imageWidth; x++)
-        blur_1D(data + x, buf + x, stride, imageHeight, intRadius);
+        blur_1D(data + x, buf + x, stride, imageHeight, radii[iteration]);
       memcpy(data, buf, stride*imageHeight);
     }
   free(buf);
@@ -2171,41 +2199,79 @@ static void start_shadow(CGContextRef ctx)
 /**
  * Draws everything between the last start_shadow call and this function
  * with a shadow.
+ *
+ * The mask holds the area that can be drawn into, in device pixels, grown by
+ * the blur radius so the blur is not cut off at its own edges.  The offset is
+ * in the base coordinate space of the context and does not go through the
+ * CTM, so the mask is placed with the matrix set aside; base space has y
+ * running up where cairo's device space has it running down.
  */
-static void end_shadow(CGContextRef ctx, CGRect bounds)
+static void end_shadow(CGContextRef ctx)
 {
   cairo_pattern_t *pattern = cairo_pop_group(ctx->ct);
-  
- // writeOut(pattern);
-  
-  cairo_save(ctx->ct);
-  
-  //#if 0
-  // Create the shadow mask
-  cairo_surface_t *alphaSurface = 
-    cairo_image_surface_create(CAIRO_FORMAT_A8, 500, 250);
-                                 //ceil(bounds.size.width + 2*radius),
-                                 //ceil(bounds.size.height + 2*radius)); 
-  cairo_t *alphaCt = cairo_create(alphaSurface);
-  //cairo_surface_set_device_offset(alphaSurface, 0, 250); 
-  //cairo_scale(alphaCt, 1.0, -1.0);
-  
-  cairo_set_source(alphaCt, pattern);
-  cairo_paint(alphaCt);
-  cairo_surface_flush(alphaSurface);
-  blur_alpha_image_surface(alphaSurface, ctx->add->shadow_radius);
-  
-  // Draw the shadow
-  // cairo_set_source(ctx->ct, ctx->add->shadow_cp);
-  cairo_set_source_rgba(ctx->ct, 0, 0, 0, 0.3); // FIXME hardcoded
-  
-  // FIXME: the offset is not supposed to be affected by the CTM
-  cairo_mask_surface(ctx->ct, alphaSurface, ctx->add->shadow_offset.width, 
-                                            ctx->add->shadow_offset.height);
-  
+  cairo_surface_t *alphaSurface;
+  cairo_matrix_t matrix, shift;
+  cairo_t *alphaCt;
+  double corners[4][2];
+  double minX, minY, maxX, maxY;
+  double x1, y1, x2, y2;
+  int grow = (int)ceil(ctx->add->shadow_radius) + 1;
+  int i, x, y, w, h;
+
+  cairo_clip_extents(ctx->ct, &x1, &y1, &x2, &y2);
+  corners[0][0] = x1; corners[0][1] = y1;
+  corners[1][0] = x2; corners[1][1] = y1;
+  corners[2][0] = x1; corners[2][1] = y2;
+  corners[3][0] = x2; corners[3][1] = y2;
+  for (i = 0; i < 4; i++)
+    cairo_user_to_device(ctx->ct, &corners[i][0], &corners[i][1]);
+
+  minX = maxX = corners[0][0];
+  minY = maxY = corners[0][1];
+  for (i = 1; i < 4; i++)
+    {
+      if (corners[i][0] < minX) minX = corners[i][0];
+      if (corners[i][0] > maxX) maxX = corners[i][0];
+      if (corners[i][1] < minY) minY = corners[i][1];
+      if (corners[i][1] > maxY) maxY = corners[i][1];
+    }
+  x = (int)floor(minX) - grow;
+  y = (int)floor(minY) - grow;
+  w = (int)ceil(maxX) + grow - x;
+  h = (int)ceil(maxY) + grow - y;
+
+  if (w > 0 && h > 0)
+    {
+      alphaSurface = cairo_image_surface_create(CAIRO_FORMAT_A8, w, h);
+      alphaCt = cairo_create(alphaSurface);
+
+      /* Draw into the mask through the same transform, moved so that device
+         point (x, y) is the mask's first pixel. */
+      cairo_get_matrix(ctx->ct, &matrix);
+      cairo_matrix_init_translate(&shift, -x, -y);
+      cairo_matrix_multiply(&matrix, &matrix, &shift);
+      cairo_set_matrix(alphaCt, &matrix);
+      cairo_set_source(alphaCt, pattern);
+      cairo_paint(alphaCt);
+      cairo_destroy(alphaCt);
+
+      cairo_surface_flush(alphaSurface);
+      blur_alpha_image_surface(alphaSurface, ctx->add->shadow_radius);
+      cairo_surface_mark_dirty(alphaSurface);
+
+      cairo_save(ctx->ct);
+      cairo_identity_matrix(ctx->ct);
+      cairo_set_source(ctx->ct, ctx->add->shadow_cp);
+      cairo_mask_surface(ctx->ct, alphaSurface,
+                         x + ctx->add->shadow_offset.width,
+                         y - ctx->add->shadow_offset.height);
+      cairo_restore(ctx->ct);
+
+      cairo_surface_destroy(alphaSurface);
+    }
+
   // Draw the actual content
   cairo_set_source(ctx->ct, pattern);
   cairo_paint(ctx->ct);
-  
-  cairo_restore(ctx->ct);
+  cairo_pattern_destroy(pattern);
 }

--- a/Source/OpalGraphics/CGContext.m
+++ b/Source/OpalGraphics/CGContext.m
@@ -46,6 +46,8 @@ extern CGRect opal_CGImageGetSourceRect(CGImageRef image);
 static inline void set_color(cairo_pattern_t **cp, CGColorRef clr, double alpha);
 static void start_shadow(CGContextRef ctx);
 static void end_shadow(CGContextRef ctx);
+static void paint_with_shadow(CGContextRef ctx, cairo_pattern_t *pattern,
+                              double alpha);
 
 
 @implementation CGContext
@@ -2054,15 +2056,24 @@ void CGContextEndTransparencyLayer(CGContextRef ctx)
 {
   OPLOGCALL("ctx /*%p*/", ctx)
   cairo_pattern_t *group = cairo_pop_group(ctx->ct);
-  
+
   // Now undo the change to alpha and shadow state
   CGContextRestoreGState(ctx);
-  
-  // Paint the contents of the transparency layer.
-  cairo_set_source(ctx->ct, group);
+
+  /* Paint the contents of the transparency layer, composited using the
+     global alpha and the shadow the context carries, so that what the layer
+     holds casts one shadow between it rather than one apiece. */
+  if (ctx->add->shadow_cp)
+    {
+      paint_with_shadow(ctx, group, ctx->add->alpha);
+    }
+  else
+    {
+      cairo_set_source(ctx->ct, group);
+      cairo_paint_with_alpha(ctx->ct, ctx->add->alpha);
+    }
   cairo_pattern_destroy(group);
-  cairo_paint_with_alpha(ctx->ct, ctx->add->alpha);
-  
+
   // Undo the clipping (if any)
   cairo_restore(ctx->ct);
   OPRESTORELOGGING()
@@ -2206,9 +2217,9 @@ static void start_shadow(CGContextRef ctx)
  * CTM, so the mask is placed with the matrix set aside; base space has y
  * running up where cairo's device space has it running down.
  */
-static void end_shadow(CGContextRef ctx)
+static void paint_with_shadow(CGContextRef ctx, cairo_pattern_t *pattern,
+                              double alpha)
 {
-  cairo_pattern_t *pattern = cairo_pop_group(ctx->ct);
   cairo_surface_t *alphaSurface;
   cairo_matrix_t matrix, shift;
   cairo_t *alphaCt;
@@ -2261,7 +2272,15 @@ static void end_shadow(CGContextRef ctx)
 
       cairo_save(ctx->ct);
       cairo_identity_matrix(ctx->ct);
-      cairo_set_source(ctx->ct, ctx->add->shadow_cp);
+      /* The colour carries the alpha the content is painted with, there
+         being no alpha to give cairo_mask_surface. */
+      {
+        double red = 0, green = 0, blue = 0, shadowAlpha = 1;
+
+        cairo_pattern_get_rgba(ctx->add->shadow_cp, &red, &green, &blue,
+                               &shadowAlpha);
+        cairo_set_source_rgba(ctx->ct, red, green, blue, shadowAlpha * alpha);
+      }
       cairo_mask_surface(ctx->ct, alphaSurface,
                          x + ctx->add->shadow_offset.width,
                          y - ctx->add->shadow_offset.height);
@@ -2272,6 +2291,17 @@ static void end_shadow(CGContextRef ctx)
 
   // Draw the actual content
   cairo_set_source(ctx->ct, pattern);
-  cairo_paint(ctx->ct);
+  cairo_paint_with_alpha(ctx->ct, alpha);
+}
+
+/**
+ * Draws everything between the last start_shadow call and this function
+ * with a shadow.
+ */
+static void end_shadow(CGContextRef ctx)
+{
+  cairo_pattern_t *pattern = cairo_pop_group(ctx->ct);
+
+  paint_with_shadow(ctx, pattern, 1.0);
   cairo_pattern_destroy(pattern);
 }

--- a/Tests/opal/CGContext/shadow.m
+++ b/Tests/opal/CGContext/shadow.m
@@ -68,6 +68,24 @@ static Box boxOf(unsigned char *d, int w, int h, int fromX, int toX)
   return b;
 }
 
+/* Pixels of the white shadow within the columns given.  Safe only where the
+   radius is 0: a blurred shadow fades out to an alpha of 1, where the
+   premultiplied colour rounds to zero and reads as black. */
+static int whiteCount(unsigned char *d, int w, int h, int fromX, int toX)
+{
+  int x, y, count = 0;
+
+  for (y = 0; y < h; y++)
+    for (x = fromX; x < toX; x++)
+      {
+        unsigned char *p = d + (y * w + x) * 4;
+
+        if (p[3] > 0 && p[0] == p[3] && p[1] == p[3] && p[2] == p[3])
+          count++;
+      }
+  return count;
+}
+
 static void black(CGContextRef ctx, CGColorSpaceRef dev)
 {
   CGFloat c[] = { 0, 0, 0, 1 };
@@ -212,6 +230,81 @@ int main(void)
   PASS(shadow.count == 0, "a shadow given no colour is not drawn");
   CGContextRelease(ctx);
   free(data);
+
+  /* A transparency layer is composited using the context's shadow, so what
+     it holds casts one shadow between them rather than one apiece.  Here a
+     second rect is drawn to the right of the first and the offset carries the
+     first one's shadow over it: drawn plainly that shadow lands on top of the
+     second rect, and out of a transparency layer it does not, because the
+     rect it would fall on is part of the same composite. */
+  {
+    int strip0 = 145, strip1 = 175;
+
+    ctx = makeCtx(dev, 200, 200, &data);
+    black(ctx, dev);
+    CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, 0), 0, white);
+    CGContextFillRect(ctx, CGRectMake(140, 70, 40, 40));
+    CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+    PASS(whiteCount(pixels(ctx), 200, 200, strip0, strip1) > 0,
+         "drawn plainly, one shadow falls over what was drawn before it");
+    CGContextRelease(ctx);
+    free(data);
+
+    ctx = makeCtx(dev, 200, 200, &data);
+    black(ctx, dev);
+    CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, 0), 0, white);
+    CGContextBeginTransparencyLayer(ctx, NULL);
+    CGContextFillRect(ctx, CGRectMake(140, 70, 40, 40));
+    CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+    CGContextEndTransparencyLayer(ctx);
+    /* The gap between the two rects, where the first one's shadow lands and
+       neither rect covers it. */
+    PASS(whiteCount(pixels(ctx), 200, 200, 130, 139) > 0,
+         "a transparency layer casts a shadow");
+    PASS(whiteCount(pixels(ctx), 200, 200, strip0, strip1) == 0,
+         "and casts one for everything in it rather than one apiece");
+    CGContextRelease(ctx);
+    free(data);
+  }
+
+  /* The global alpha reaches that shadow too, the layer being composited
+     with it. */
+  {
+    int x, y, plainPeak = 0, fadedPeak = 0;
+    unsigned char *p;
+
+    ctx = makeCtx(dev, 200, 200, &data);
+    black(ctx, dev);
+    CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 0, white);
+    CGContextBeginTransparencyLayer(ctx, NULL);
+    CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+    CGContextEndTransparencyLayer(ctx);
+    p = pixels(ctx);
+    for (y = 0; y < 200; y++)
+      for (x = 120; x < 200; x++)
+        if (p[(y * 200 + x) * 4 + 3] > plainPeak)
+          plainPeak = p[(y * 200 + x) * 4 + 3];
+    CGContextRelease(ctx);
+    free(data);
+
+    ctx = makeCtx(dev, 200, 200, &data);
+    black(ctx, dev);
+    CGContextSetAlpha(ctx, 0.5);
+    CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 0, white);
+    CGContextBeginTransparencyLayer(ctx, NULL);
+    CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+    CGContextEndTransparencyLayer(ctx);
+    p = pixels(ctx);
+    for (y = 0; y < 200; y++)
+      for (x = 120; x < 200; x++)
+        if (p[(y * 200 + x) * 4 + 3] > fadedPeak)
+          fadedPeak = p[(y * 200 + x) * 4 + 3];
+    CGContextRelease(ctx);
+    free(data);
+
+    PASS(plainPeak == 255 && fadedPeak >= 126 && fadedPeak <= 130,
+         "a global alpha of one half halves that shadow");
+  }
 
   END_SET("CGContext shadow")
 

--- a/Tests/opal/CGContext/shadow.m
+++ b/Tests/opal/CGContext/shadow.m
@@ -1,0 +1,221 @@
+/* CGContextSetShadow and CGContextSetShadowWithColor.  Expected values
+   checked against Apple CoreGraphics on a macOS runner: a filled path's
+   shadow covers that path moved by the offset and grown by the radius on
+   every side, it is drawn in the colour that was set, and it is drawn
+   wherever in the context the path is.  CGContextSetShadow uses black at one
+   third alpha.
+
+   Every case puts the offset further to the right than the path is wide, so
+   the shadow and the path fall in different halves of the context and can be
+   measured apart.  Colour is not used to tell them apart: a shadow fades out
+   to an alpha of 1, where the premultiplied colour rounds to zero and reads
+   as black whatever colour it was given.
+
+   Which way user space y runs in the buffer is measured here rather than
+   assumed, so the offset can be asserted with its sign either way. */
+#include "Testing.h"
+
+#include <CoreGraphics/CGContext.h>
+#include <CoreGraphics/CGBitmapContext.h>
+#include <CoreGraphics/CGColorSpace.h>
+#include <CoreGraphics/CGColor.h>
+#include <CoreGraphics/CGGeometry.h>
+#include <stdlib.h>
+
+#define OFFSET 60
+
+typedef struct
+{
+  int x0, y0, x1, y1, count;
+} Box;
+
+static CGContextRef makeCtx(CGColorSpaceRef dev, int w, int h,
+                            unsigned char **data)
+{
+  *data = calloc(w * h * 4, 1);
+  return CGBitmapContextCreate(*data, w, h, 8, w * 4, dev,
+                               kCGImageAlphaPremultipliedLast);
+}
+
+/* What has been drawn so far.  Reading the buffer that was handed to
+   CGBitmapContextCreate is not enough: what is drawn reaches it only once
+   the context has been asked for it. */
+static unsigned char *pixels(CGContextRef ctx)
+{
+  return (unsigned char *)CGBitmapContextGetData(ctx);
+}
+
+/* The box of pixels with any coverage at all, within the columns given. */
+static Box boxOf(unsigned char *d, int w, int h, int fromX, int toX)
+{
+  Box b = { w, h, -1, -1, 0 };
+  int x, y;
+
+  for (y = 0; y < h; y++)
+    for (x = fromX; x < toX; x++)
+      {
+        unsigned char *p = d + (y * w + x) * 4;
+
+        if (p[3] > 0)
+          {
+            b.count++;
+            if (x < b.x0) b.x0 = x;
+            if (x > b.x1) b.x1 = x;
+            if (y < b.y0) b.y0 = y;
+            if (y > b.y1) b.y1 = y;
+          }
+      }
+  return b;
+}
+
+static void black(CGContextRef ctx, CGColorSpaceRef dev)
+{
+  CGFloat c[] = { 0, 0, 0, 1 };
+  CGColorRef color = CGColorCreate(dev, c);
+
+  CGContextSetFillColorWithColor(ctx, color);
+  CGContextSetStrokeColorWithColor(ctx, color);
+  CGColorRelease(color);
+}
+
+int main(void)
+{
+  CGColorSpaceRef dev = CGColorSpaceCreateDeviceRGB();
+  CGFloat whiteComponents[] = { 1, 1, 1, 1 };
+  CGColorRef white = CGColorCreate(dev, whiteComponents);
+
+  START_SET("CGContext shadow")
+
+  unsigned char *data;
+  CGContextRef ctx;
+  Box fill, shadow;
+  int yStep;
+
+  /* Which row a rect at the bottom of user space lands in.  If it lands in
+     the last rows then user space y runs the opposite way to the rows, and a
+     positive offset moves the shadow towards row zero. */
+  ctx = makeCtx(dev, 40, 40, &data);
+  black(ctx, dev);
+  CGContextFillRect(ctx, CGRectMake(0, 0, 40, 8));
+  fill = boxOf(pixels(ctx), 40, 40, 0, 40);
+  yStep = fill.y0 >= 20 ? -1 : 1;
+  CGContextRelease(ctx);
+  free(data);
+
+  /* A shadow with no blur is the path moved by the offset. */
+  ctx = makeCtx(dev, 200, 200, &data);
+  black(ctx, dev);
+  CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 0, white);
+  CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+  fill = boxOf(pixels(ctx), 200, 200, 0, 120);
+  shadow = boxOf(pixels(ctx), 200, 200, 120, 200);
+
+  PASS(shadow.count > 0, "a filled rect casts a shadow");
+  PASS(shadow.x1 - shadow.x0 == fill.x1 - fill.x0
+       && shadow.y1 - shadow.y0 == fill.y1 - fill.y0,
+       "a shadow with a radius of 0 is the same size as what casts it");
+  PASS(shadow.x0 - fill.x0 == OFFSET
+       && shadow.y0 - fill.y0 == OFFSET * yStep,
+       "and sits at the offset it was given");
+  {
+    int x = (shadow.x0 + shadow.x1) / 2;
+    int y = (shadow.y0 + shadow.y1) / 2;
+    unsigned char *p = pixels(ctx) + (y * 200 + x) * 4;
+
+    PASS(p[0] == 255 && p[1] == 255 && p[2] == 255 && p[3] == 255,
+         "a shadow is drawn in the colour it was given");
+  }
+  CGContextRelease(ctx);
+  free(data);
+
+  /* The radius grows the shadow by that much on every side. */
+  ctx = makeCtx(dev, 200, 200, &data);
+  black(ctx, dev);
+  CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 5, white);
+  CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+  fill = boxOf(pixels(ctx), 200, 200, 0, 120);
+  shadow = boxOf(pixels(ctx), 200, 200, 120, 200);
+
+  PASS(shadow.count > 0
+       && shadow.x1 - shadow.x0 == (fill.x1 - fill.x0) + 10,
+       "a radius of 5 grows the shadow by 5 on each side");
+  PASS(shadow.count > 0
+       && shadow.y1 - shadow.y0 == (fill.y1 - fill.y0) + 10,
+       "in both directions");
+  CGContextRelease(ctx);
+  free(data);
+
+  /* Far from the origin, past any fixed-size intermediate buffer. */
+  ctx = makeCtx(dev, 600, 600, &data);
+  black(ctx, dev);
+  CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 0, white);
+  CGContextFillRect(ctx, CGRectMake(450, 450, 40, 40));
+  shadow = boxOf(pixels(ctx), 600, 600, 500, 600);
+
+  PASS(shadow.count > 0,
+       "a rect far from the origin casts a shadow as well");
+  PASS(shadow.count == 1600,
+       "and the whole of it is drawn");
+  CGContextRelease(ctx);
+  free(data);
+
+  /* CGContextSetShadow's own colour. */
+  ctx = makeCtx(dev, 200, 200, &data);
+  black(ctx, dev);
+  CGContextSetShadow(ctx, CGSizeMake(OFFSET, OFFSET), 0);
+  CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+  shadow = boxOf(pixels(ctx), 200, 200, 120, 200);
+  {
+    int x = (shadow.x0 + shadow.x1) / 2;
+    int y = (shadow.y0 + shadow.y1) / 2;
+    unsigned char *p = pixels(ctx) + (y * 200 + x) * 4;
+
+    PASS(p[0] == 0 && p[1] == 0 && p[2] == 0 && p[3] >= 84 && p[3] <= 86,
+         "CGContextSetShadow draws black at one third alpha");
+  }
+  CGContextRelease(ctx);
+  free(data);
+
+  /* A stroke casts one too. */
+  ctx = makeCtx(dev, 200, 200, &data);
+  black(ctx, dev);
+  CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 0, white);
+  CGContextSetLineWidth(ctx, 4);
+  CGContextBeginPath(ctx);
+  CGContextAddRect(ctx, CGRectMake(70, 70, 40, 40));
+  CGContextStrokePath(ctx);
+  shadow = boxOf(pixels(ctx), 200, 200, 120, 200);
+  PASS(shadow.count > 0, "a stroked path casts a shadow");
+  CGContextRelease(ctx);
+  free(data);
+
+  /* The shadow belongs to the graphics state. */
+  ctx = makeCtx(dev, 200, 200, &data);
+  black(ctx, dev);
+  CGContextSaveGState(ctx);
+  CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 0, white);
+  CGContextRestoreGState(ctx);
+  CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+  shadow = boxOf(pixels(ctx), 200, 200, 120, 200);
+  PASS(shadow.count == 0,
+       "a shadow set inside a saved state is gone once it is restored");
+  CGContextRelease(ctx);
+  free(data);
+
+  /* A NULL colour turns it off as well. */
+  ctx = makeCtx(dev, 200, 200, &data);
+  black(ctx, dev);
+  CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 0, white);
+  CGContextSetShadowWithColor(ctx, CGSizeMake(OFFSET, OFFSET), 0, NULL);
+  CGContextFillRect(ctx, CGRectMake(70, 70, 40, 40));
+  shadow = boxOf(pixels(ctx), 200, 200, 120, 200);
+  PASS(shadow.count == 0, "a shadow given no colour is not drawn");
+  CGContextRelease(ctx);
+  free(data);
+
+  END_SET("CGContext shadow")
+
+  CGColorRelease(white);
+  CGColorSpaceRelease(dev);
+  return 0;
+}


### PR DESCRIPTION
CGContextEndTransparencyLayer painted the layer's contents with the global alpha but not with the shadow, so nothing drawn inside a transparency layer ever cast one. Apple documents the result as composited into the context using the global alpha and shadow state of the context, both of them turned off inside the layer, which is what makes a group cast one shadow between it rather than one per drawing operation.

The shadow painting out of end_shadow is now a function of its own taking the group pattern and an alpha, and CGContextEndTransparencyLayer calls it where the context carries a shadow. The alpha multiplies the shadow colour, cairo_mask_surface having none of its own to take.

Tests/opal/CGContext/shadow.m gains four assertions, two of which failed before: a transparency layer casts a shadow, and a global alpha of one half halves it. The other two hold either way and pin down what the layer changes: drawn plainly, one rect's shadow falls over a rect drawn before it, and out of a transparency layer it does not.

The suite goes from 203 passed and 2 failed to 205 and 0.

Stacks on #64.
