### PR TITLE
Declare StandardGlyphNames rather than define it

### DIFF
--- a/Source/OpalGraphics/cairo/StandardGlyphNames.h
+++ b/Source/OpalGraphics/cairo/StandardGlyphNames.h
@@ -25,4 +25,4 @@
 /**
  * Standatd glyph names 0-257
  */   
-const char * const StandardGlyphNames[258];
+extern const char * const StandardGlyphNames[258];


### PR DESCRIPTION
StandardGlyphNames.h declares

    const char * const StandardGlyphNames[258];

Without extern that is a tentative definition, so every translation unit including the header emits its own. It linked while compilers defaulted to -fcommon. clang 11 and later default to -fno-common, and the link fails with a duplicate symbol.

It appears on Windows because CairoFontWin32.m is the second unit to include the header. On other platforms that file compiles to nothing, so StandardGlyphNames.m is the only definition and the declaration is never exercised.

Found building on MSYS2 ucrt64 with clang 22.
