### PR TITLE
Keep the interface macro alive for the JPEG headers on MinGW

### DIFF
--- a/Source/OpalGraphics/image/OPImageCodecJPEG.m
+++ b/Source/OpalGraphics/image/OPImageCodecJPEG.m
@@ -56,7 +56,21 @@ typedef int jpeg_boolean;
 #endif
 #endif // __MINGW32__
 
+/* basetyps.h defines `interface` and Foundation undefines it, but
+ * shlwapi.h, which jmorecfg.h includes here, still needs it.  It is
+ * withdrawn again below, because while it stands `@interface` in this
+ * file expands to `@struct`.
+ */
+#if defined(__MINGW32__) && !defined(interface)
+#define interface struct
+#define OPAL_UNDEF_INTERFACE 1
+#endif
 #include <jpeglib.h>
+#if defined(OPAL_UNDEF_INTERFACE)
+#undef interface
+#undef OPAL_UNDEF_INTERFACE
+#endif
+
 
 
 


### PR DESCRIPTION
basetyps.h defines interface as struct. Foundation undefines it, because it collides with Objective-C. jmorecfg.h then includes shlwapi.h on MinGW, which still uses interface, and shlwapi.h fails to parse with "unknown type name 'interface'".

Foundation is imported at the top of the file, so the macro is already gone by the time the JPEG headers arrive. It is restored across those headers only.

It has to be withdrawn immediately afterwards: while it stands, an @interface in this file expands to @struct and the compiler reports "unexpected '@' in program".

Found building on MSYS2 ucrt64.
