### PR TITLE
Keep building where incompatible pointer types are an error

### DIFF
--- a/Source/GNUmakefile.preamble
+++ b/Source/GNUmakefile.preamble
@@ -1,0 +1,6 @@
+
+# clang 19 and later make -Wincompatible-pointer-types an error by
+# default.  The CoreFoundation and Foundation types here are toll-free
+# bridged, so the static types differ where the objects do not.
+ADDITIONAL_OBJCFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion
+ADDITIONAL_CFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion

--- a/Source/OpalGraphics/CGColor.m
+++ b/Source/OpalGraphics/CGColor.m
@@ -29,9 +29,9 @@
 #import "CGColorSpace-private.h"
 #import "OPImageConversion.h"
 
-const CFStringRef kCGColorWhite = @"kCGColorWhite";
-const CFStringRef kCGColorBlack = @"kCGColorBlack";
-const CFStringRef kCGColorClear = @"kCGColorClear";
+const CFStringRef kCGColorWhite = (CFStringRef)@"kCGColorWhite";
+const CFStringRef kCGColorBlack = (CFStringRef)@"kCGColorBlack";
+const CFStringRef kCGColorClear = (CFStringRef)@"kCGColorClear";
 
 static CGColorRef _whiteColor;
 static CGColorRef _blackColor;
@@ -244,7 +244,7 @@ const CGFloat *CGColorGetComponents(CGColorRef clr)
 
 CGColorRef CGColorGetConstantColor(CFStringRef name)
 {
-  if ([name isEqual: kCGColorWhite])
+  if ([(id)name isEqual: (id)kCGColorWhite])
   {
     if (nil == _whiteColor)
     {
@@ -252,7 +252,7 @@ CGColorRef CGColorGetConstantColor(CFStringRef name)
     }
     return  _whiteColor;
   }
-  else if ([name isEqual: kCGColorBlack])
+  else if ([(id)name isEqual: (id)kCGColorBlack])
   {
     if (nil == _blackColor)
     {
@@ -260,7 +260,7 @@ CGColorRef CGColorGetConstantColor(CFStringRef name)
     }
     return _blackColor;
   }
-  else if ([name isEqual: kCGColorClear])
+  else if ([(id)name isEqual: (id)kCGColorClear])
   {
     if (nil == _clearColor)
     {

--- a/Source/OpalGraphics/GNUmakefile.preamble
+++ b/Source/OpalGraphics/GNUmakefile.preamble
@@ -1,0 +1,6 @@
+
+# clang 19 and later make -Wincompatible-pointer-types an error by
+# default.  The CoreFoundation and Foundation types here are toll-free
+# bridged, so the static types differ where the objects do not.
+ADDITIONAL_OBJCFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion
+ADDITIONAL_CFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion

--- a/Source/OpalText/GNUmakefile.preamble
+++ b/Source/OpalText/GNUmakefile.preamble
@@ -1,0 +1,6 @@
+
+# clang 19 and later make -Wincompatible-pointer-types an error by
+# default.  The CoreFoundation and Foundation types here are toll-free
+# bridged, so the static types differ where the objects do not.
+ADDITIONAL_OBJCFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion
+ADDITIONAL_CFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion

--- a/Tests/GNUmakefile.preamble
+++ b/Tests/GNUmakefile.preamble
@@ -1,0 +1,6 @@
+
+# clang 19 and later make -Wincompatible-pointer-types an error by
+# default.  The CoreFoundation and Foundation types here are toll-free
+# bridged, so the static types differ where the objects do not.
+ADDITIONAL_OBJCFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion
+ADDITIONAL_CFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion


### PR DESCRIPTION
CoreFoundation and Foundation types are toll-free bridged here, so the static types differ in many places where the objects do not. Every clang this has been built with treated that as a warning.

clang 19 and later make -Wincompatible-pointer-types an error by default, and opal no longer builds. This is not specific to any platform; it arrives with the toolchain.

The colour constants in CGColor.m are made explicit, and the diagnostic is returned to a warning so the rest can be worked through separately. No semantics change. A build here reports 283 of them, which is the size of that cleanup.

Found with clang 22 on MSYS2 ucrt64; clang 18 still warns.
